### PR TITLE
Add LTR pipeline, resource limits & UI tweaks

### DIFF
--- a/airflow/airflow-dags/graph_train_dag.py
+++ b/airflow/airflow-dags/graph_train_dag.py
@@ -2,6 +2,7 @@ from airflow import DAG
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.models import Variable
 from datetime import datetime, timedelta
+from kubernetes.client import models as k8s
 
 default_args = {
     "owner": "airflow",
@@ -27,6 +28,11 @@ with DAG(
         is_delete_operator_pod=True,
         in_cluster=True,
         get_logs=True,
+        # Resource limits to ensure sufficient memory
+        container_resources=k8s.V1ResourceRequirements(
+            requests={"memory": "1Gi", "cpu": "500m"},
+            limits={"memory": "4Gi", "cpu": "2"},
+        ),
         env_vars={
             "NEO4J_URI": Variable.get("NEO4J_URI", default_var=""),
             "NEO4J_USER": Variable.get("NEO4J_USER", default_var="neo4j"),

--- a/airflow/airflow-dags/linucb_train_dag.py
+++ b/airflow/airflow-dags/linucb_train_dag.py
@@ -28,6 +28,7 @@ with DAG(
         is_delete_operator_pod=True,
         in_cluster=True,
         get_logs=True,
+        # Resource limits to ensure sufficient memory
         container_resources=k8s.V1ResourceRequirements(
             requests={"memory": "1Gi", "cpu": "500m"},
             limits={"memory": "4Gi", "cpu": "2"},    

--- a/airflow/airflow-dags/ltr_train_dag.py
+++ b/airflow/airflow-dags/ltr_train_dag.py
@@ -7,24 +7,24 @@ from kubernetes.client import models as k8s
 default_args = {
     "owner": "airflow",
     "retries": 0,
-    "retry_delay": timedelta(minutes=5)
+    "retry_delay": timedelta(minutes=5),
 }
 
 with DAG(
-    dag_id="als_cf_training",
+    dag_id="ltr_training",
     default_args=default_args,
     schedule="@daily",
     start_date=datetime.utcnow() - timedelta(days=1),
     catchup=False,
-    tags=["recommendation", "ALS"]
+    tags=["recommendation", "learning-to-rank"],
 ) as dag:
 
-    als_job = KubernetesPodOperator(
+    ltr_job = KubernetesPodOperator(
         namespace="default",
-        image="rahulkrish28/als-train:latest",
-        cmds=["/app/entrypoint.sh"], 
-        name="als-trainer",
-        task_id="als_cf_train_task",
+        image="rahulkrish28/ltr-train:latest",
+        cmds=["/app/entrypoint.sh"],
+        name="ltr-trainer",
+        task_id="ltr_training_task",
         is_delete_operator_pod=True,
         in_cluster=True,
         get_logs=True,
@@ -36,9 +36,10 @@ with DAG(
         env_vars={
             "MONGO_URI": Variable.get("MONGO_URI", default_var=""),
             "S3_URI": Variable.get("S3_URI", default_var=""),
-            "ALS_S3_PREFIX": Variable.get("ALS_S3_PREFIX", default_var="ALS_Train"),
+            "LTR_S3_PREFIX": Variable.get("LTR_S3_PREFIX", default_var="LTR_Train"),
+            "FEAST_REPO_PATH": "/app/feature_repo",
+            "LTR_EVENT_DAYS": Variable.get("LTR_EVENT_DAYS", default_var="90"),
             "AWS_ACCESS_KEY_ID": Variable.get("AWS_ACCESS_KEY_ID", default_var=""),
             "AWS_SECRET_ACCESS_KEY": Variable.get("AWS_SECRET_ACCESS_KEY", default_var=""),
-            "RAY_ADDRESS": "local"
         },
     )

--- a/airflow/airflow-dags/popularity_dag.py
+++ b/airflow/airflow-dags/popularity_dag.py
@@ -13,7 +13,7 @@ default_args = {
 with DAG(
     dag_id="popularity_training",
     default_args=default_args,
-    schedule="@hourly",  # Every hour
+    schedule="@hourly", 
     start_date=datetime.utcnow() - timedelta(days=1),
     catchup=False,
     tags=["recommendation", "popularity"],

--- a/airflow/airflow-dags/sasrec_train_dag.py
+++ b/airflow/airflow-dags/sasrec_train_dag.py
@@ -29,13 +29,7 @@ with DAG(
         is_delete_operator_pod=True,
         in_cluster=True,
         get_logs=True,
-        # Schedule only on dedicated SASRec node (if it exists)
-        # TODO: Uncomment after recreating cluster with dedicated node
-        # If node doesn't exist, the pod won't schedule - comment out to use any node
-        # node_selector={"workload": "sasrec-training"},
         # Resource limits to ensure sufficient memory
-        # Start with minimal requests - increase if needed after confirming it works
-        # If pod still doesn't schedule, comment out container_resources entirely
         container_resources=k8s.V1ResourceRequirements(
             requests={"memory": "1Gi", "cpu": "500m"},
             limits={"memory": "6Gi", "cpu": "4"},

--- a/feast_feature_store/feature_repo/feature_store.yaml
+++ b/feast_feature_store/feature_repo/feature_store.yaml
@@ -1,13 +1,14 @@
 project: bibliophileai
 provider: local
 
-# S3 Registry for shared access
-registry: s3://bibliophile-ai-feast/registry/registry.db
+registry:
+  path: s3://bibliophile-ai-feast/registry/registry.db
+  cache_ttl_seconds: 86400
 
-# Redis for online features
+# Redis for Feast online store 
 online_store:
   type: redis
-  connection_string: localhost:6379
+  connection_string: feast-redis:6379
   key_ttl_seconds: 86400
 
 # S3 for offline features

--- a/frontend/bibliophile-ai-frontend/package-lock.json
+++ b/frontend/bibliophile-ai-frontend/package-lock.json
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -375,9 +375,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -477,9 +477,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
       "cpu": [
         "arm64"
       ],
@@ -698,9 +698,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -2278,9 +2278,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2291,32 +2291,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -2858,9 +2858,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -3438,12 +3438,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3453,13 +3453,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3891,18 +3891,18 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-      "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/frontend/bibliophile-ai-frontend/src/components/NetflixStyles.css
+++ b/frontend/bibliophile-ai-frontend/src/components/NetflixStyles.css
@@ -1,0 +1,266 @@
+/* Netflix-style CSS for BibliophileAI */
+
+.netflix-container {
+  padding: 0;
+  background-color: #141414;
+  min-height: 100vh;
+  color: #fff;
+}
+
+.netflix-row {
+  margin-bottom: 3rem;
+  padding: 0 4%;
+}
+
+.netflix-row-title {
+  font-size: 1.4vw;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #e5e5e5;
+  padding-left: 0;
+}
+
+.netflix-row-description {
+  font-size: 0.9vw;
+  color: #b3b3b3;
+  margin-bottom: 1rem;
+  padding-left: 0;
+}
+
+.netflix-row-content {
+  position: relative;
+}
+
+.netflix-slider {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  padding: 1rem 56px 1rem 56px; /* space for left/right scroll buttons */
+  gap: 0.5rem;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+}
+
+.netflix-slider::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
+.netflix-item {
+  flex: 0 0 auto;
+  width: 200px;
+  height: 300px;
+  position: relative;
+  cursor: pointer;
+  transition: transform 0.3s ease, z-index 0.3s ease;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.netflix-item:hover {
+  transform: scale(1.15);
+  z-index: 10;
+}
+
+.netflix-item-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.netflix-item-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+  color: white;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border-radius: 4px;
+}
+
+.netflix-item-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.9) 0%, transparent 100%);
+  padding: 1rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  border-radius: 0 0 4px 4px;
+}
+
+.netflix-item:hover .netflix-item-overlay {
+  opacity: 1;
+}
+
+.netflix-item-overlay h4 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.netflix-item-overlay p {
+  font-size: 0.75rem;
+  color: #b3b3b3;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Scroll buttons - always visible, Netflix-style */
+.netflix-scroll-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(20, 20, 20, 0.85);
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  width: 56px;
+  min-height: 300px;
+  cursor: pointer;
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease;
+  border-radius: 0 4px 4px 0;
+  box-shadow: 2px 0 12px rgba(0, 0, 0, 0.5);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.netflix-scroll-button:hover {
+  background: rgba(229, 9, 20, 0.9);
+  color: #fff;
+}
+
+.netflix-scroll-button:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.netflix-scroll-button.left {
+  left: 0;
+  border-radius: 4px 0 0 4px;
+  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.5);
+}
+
+.netflix-scroll-button.right {
+  right: 0;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .netflix-row {
+    padding: 0 2%;
+  }
+
+  .netflix-row-title {
+    font-size: 1.2rem;
+  }
+
+  .netflix-row-description {
+    font-size: 0.85rem;
+  }
+
+  .netflix-item {
+    width: 150px;
+    height: 225px;
+  }
+
+  .netflix-slider {
+    padding-left: 44px;
+    padding-right: 44px;
+  }
+
+  .netflix-scroll-button {
+    width: 44px;
+    min-height: 225px;
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .netflix-item {
+    width: 120px;
+    height: 180px;
+  }
+
+  .netflix-row-title {
+    font-size: 1rem;
+  }
+
+  .netflix-slider {
+    padding-left: 36px;
+    padding-right: 36px;
+  }
+
+  .netflix-scroll-button {
+    width: 36px;
+    min-height: 180px;
+    font-size: 1.25rem;
+  }
+}
+
+/* Dark theme adjustments */
+.netflix-container {
+  background-color: #141414;
+}
+
+/* Smooth scrolling */
+.netflix-slider {
+  scroll-padding: 1rem;
+}
+
+/* Loading state - high contrast, Netflix-style */
+.netflix-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  color: #b3b3b3;
+}
+
+.netflix-loading-state {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+  gap: 1.5rem;
+  background: #141414;
+}
+
+.netflix-loading-state .netflix-loading-text {
+  color: #e5e5e5;
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.netflix-loading-state .netflix-loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid rgba(229, 9, 20, 0.3);
+  border-top-color: #e50914;
+  border-radius: 50%;
+  animation: netflix-spin 0.9s linear infinite;
+}
+
+@keyframes netflix-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/bibliophile-ai-frontend/src/index.css
+++ b/frontend/bibliophile-ai-frontend/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #141414;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -64,17 +64,23 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* Netflix-style dark theme - override light mode */
+:root {
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #141414;
+}
+
+a:hover {
+  color: #e50914; /* Netflix red */
+}
+
+button {
+  background-color: #e50914;
+  color: white;
+}
+
+button:hover {
+  background-color: #f40612;
 }
 
 .blur-sm {

--- a/kubernetes/recommendation-deployment.yaml
+++ b/kubernetes/recommendation-deployment.yaml
@@ -97,11 +97,19 @@ spec:
             secretKeyRef:
               name: secret
               key: MONGO_URI
+        # General recommendation cache (redis from redis.yaml)
         - name: REDIS_URL
           valueFrom:
             secretKeyRef:
               name: secret
               key: REDIS_URL
+        # Feast online store (feast-redis from redis-feast.yaml); 
+        - name: FEAST_REDIS_URL
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: FEAST_REDIS_URL
+
         - name: LINUCB_S3_PREFIX
           valueFrom:
             secretKeyRef:
@@ -112,4 +120,9 @@ spec:
             secretKeyRef:
               name: secret
               key: GRAPH_S3_PREFIX
+        - name: INTERNAL_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: INTERNAL_API_KEY
 

--- a/kubernetes/redis-feast.yaml
+++ b/kubernetes/redis-feast.yaml
@@ -1,3 +1,4 @@
+# Feast online store only (FEAST_REDIS_URL in recommendation-service)
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes/redis.yaml
+++ b/kubernetes/redis.yaml
@@ -1,3 +1,4 @@
+# General cache: recommendation cache, session, etc. (REDIS_URL in recommendation-service)
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/user-auth-deployment.yaml
+++ b/kubernetes/user-auth-deployment.yaml
@@ -92,4 +92,14 @@ spec:
             secretKeyRef:
               name: secret
               key: NEO4J_PASSWORD
+        - name: RECOMMENDATION_SERVICE_URL
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: RECOMMENDATION_SERVICE_URL         
+        - name: INTERNAL_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret
+              key: INTERNAL_API_KEY
 

--- a/src/model_training_service/als_train/Dockerfile
+++ b/src/model_training_service/als_train/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.10
 
 WORKDIR /app
 
-COPY als_train.py .
 COPY requirements.txt .
 COPY entrypoint.sh .
 
@@ -10,4 +9,5 @@ RUN chmod +x entrypoint.sh \
     && pip install --upgrade pip \
     && pip install -r requirements.txt
 
+COPY als_train.py .
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/model_training_service/graph_train/Dockerfile
+++ b/src/model_training_service/graph_train/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.10
 
 WORKDIR /app
 
-COPY graph_train.py .
 COPY requirements.txt .
 COPY entrypoint.sh .
 
@@ -10,4 +9,5 @@ RUN chmod +x entrypoint.sh \
     && pip install --upgrade pip \
     && pip install -r requirements.txt
 
+COPY graph_train.py .
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/model_training_service/linucb_train/Dockerfile
+++ b/src/model_training_service/linucb_train/Dockerfile
@@ -2,13 +2,14 @@ FROM python:3.10
 
 WORKDIR /app
 
-COPY linucb_train.py .
-COPY helper.py .
 COPY requirements.txt .
 COPY entrypoint.sh .
 
 RUN chmod +x entrypoint.sh \
     && pip install --upgrade pip \
     && pip install -r requirements.txt
+
+COPY linucb_train.py .
+COPY helper.py .
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/model_training_service/ltr_train/Dockerfile
+++ b/src/model_training_service/ltr_train/Dockerfile
@@ -1,0 +1,18 @@
+# Build from repo root only (context must include feast_feature_store and src/):
+#   cd /path/to/BibliophileAI
+#   docker build -f src/model_training_service/ltr_train/Dockerfile -t rahulkrish28/ltr-train:latest .
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY src/model_training_service/ltr_train/requirements.txt .
+COPY src/model_training_service/ltr_train/entrypoint.sh .
+
+RUN chmod +x entrypoint.sh \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY src/model_training_service/ltr_train/ltr_train.py .
+COPY feast_feature_store/feature_repo /app/feature_repo
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/src/model_training_service/ltr_train/entrypoint.sh
+++ b/src/model_training_service/ltr_train/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+echo "Running LTR (Learning-to-Rank) training..."
+python ltr_train.py
+echo "LTR training finished."

--- a/src/model_training_service/ltr_train/ltr_train.py
+++ b/src/model_training_service/ltr_train/ltr_train.py
@@ -1,0 +1,341 @@
+import os
+import sys
+import logging
+from datetime import datetime, timedelta
+from collections import defaultdict
+import pandas as pd
+import numpy as np
+from pymongo import MongoClient
+import boto3
+import io
+from feast import FeatureStore
+import xgboost as xgb
+import boto3
+from io import BytesIO
+import tempfile
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+MONGO_URI = os.environ.get("MONGO_URI")
+S3_URI = os.environ.get("S3_URI", "").rstrip("/")
+LTR_S3_PREFIX = os.environ.get("LTR_S3_PREFIX", "LTR_Train")
+FEAST_REPO_PATH = os.environ.get("FEAST_REPO_PATH", "")
+FEAST_S3_BUCKET = os.environ.get("FEAST_S3_BUCKET", "bibliophile-ai-feast")
+EVENT_DAYS = int(os.environ.get("LTR_EVENT_DAYS", "90"))
+
+# Relevance: 5=completed+rated>=4, 4=completed, 3=read>=50%, 2=read>=10%, 1=click, 0=ignore
+VALID_EVENTS = {"read", "page_turn", "review", "bookmark_add"}
+
+FEATURE_COLS = [
+    "retrieval_0", "retrieval_1", "retrieval_2", "retrieval_3", "retrieval_4", "retrieval_5",
+    "genre_match_count", "author_match", "language_match",
+    "avg_rating", "user_rating", "avg_rating_diff", "rating_count", "user_pref_strength",
+    "friend_reads_count", "friend_avg_rating", "author_following", "mutual_likes", "social_proximity",
+    "session_position", "session_genre_drift", "time_since_last_action",
+    "is_mobile", "is_desktop", "is_tablet", "session_length",
+    "global_pop_rank", "trending_score", "intra_list_diversity",
+]
+
+
+def get_relevance_labels_from_mongo() -> pd.DataFrame:
+    """
+    Aggregate (user_id, item_id) -> relevance 0-5 from click_stream.events.
+    Returns DataFrame with columns: user_id, book_id, user_book, relevance, event_timestamp.
+    """
+    client = MongoClient(MONGO_URI)
+    col = client["click_stream"]["events"]
+    end = datetime.utcnow()
+    start = end - timedelta(days=EVENT_DAYS)
+    pipeline = [
+        {"$match": {
+            "event_type": {"$in": list(VALID_EVENTS)},
+            "received_at": {"$gte": start, "$lte": end},
+        }},
+        {"$group": {
+            "_id": {"user_id": "$user_id", "item_id": "$item_id"},
+            "events": {"$push": {"type": "$event_type", "at": "$received_at", "meta": "$metadata"}},
+            "last_at": {"$max": "$received_at"},
+        }},
+    ]
+    rows = []
+    for doc in col.aggregate(pipeline):
+        uid = doc["_id"]["user_id"]
+        bid = doc["_id"]["item_id"]
+        events = doc.get("events", [])
+        last_at = doc.get("last_at", end)
+        rel = 0
+        for e in events:
+            t = e.get("type")
+            meta = e.get("meta") or {}
+            if t == "review":
+                rating = meta.get("rating") or 0
+                if rating >= 4:
+                    rel = max(rel, 5)
+                else:
+                    rel = max(rel, 4)
+            elif t == "read":
+                rel = max(rel, 4)
+            elif t == "page_turn":
+                # Proxy: many page_turns -> 3, else 2
+                count = sum(1 for x in events if (x.get("type")) == "page_turn")
+                rel = max(rel, 3 if count >= 5 else 2)
+            elif t == "bookmark_add":
+                rel = max(rel, 1)
+        rows.append({
+            "user_id": uid,
+            "book_id": str(bid),
+            "user_book": f"{uid}_{bid}",
+            "relevance": rel,
+            "timestamp": last_at,
+        })
+    if not rows:
+        logger.warning("No events found for relevance labels")
+        return pd.DataFrame()
+    return pd.DataFrame(rows)
+
+
+def get_historical_features_from_feast(entity_df: pd.DataFrame) -> pd.DataFrame:
+    """Load user-book features from Feast offline store (S3 Parquet).
+    Note: Feast may use registry/materialization metadata, so it can return data from
+    previously known parquet paths even after you delete files. For latest S3 state,
+    use get_historical_features_direct_s3() instead."""
+
+    repo_path = FEAST_REPO_PATH
+    if not os.path.isdir(repo_path):
+        logger.warning(f"Feast repo not found at {repo_path}")
+        return pd.DataFrame()
+
+    # Feast requires event_timestamp with datetime dtype
+    entity_df = entity_df[["user_book", "timestamp"]].drop_duplicates()
+
+    if not pd.api.types.is_datetime64_any_dtype(entity_df["timestamp"]):
+        entity_df["timestamp"] = pd.to_datetime(entity_df["timestamp"], utc=True)
+
+    store = FeatureStore(repo_path=repo_path)
+
+    feature_names = [
+        "user_book_features:query_id",
+        "user_book_features:user_id",
+        "user_book_features:book_id",
+        "user_book_features:retrieval_0",
+        "user_book_features:retrieval_1",
+        "user_book_features:retrieval_2",
+        "user_book_features:retrieval_3",
+        "user_book_features:retrieval_4",
+        "user_book_features:retrieval_5",
+        "user_book_features:genre_match_count",
+        "user_book_features:author_match",
+        "user_book_features:language_match",
+        "user_book_features:avg_rating",
+        "user_book_features:user_rating",
+        "user_book_features:avg_rating_diff",
+        "user_book_features:rating_count",
+        "user_book_features:user_pref_strength",
+        "user_book_features:friend_reads_count",
+        "user_book_features:friend_avg_rating",
+        "user_book_features:author_following",
+        "user_book_features:mutual_likes",
+        "user_book_features:social_proximity",
+        "user_book_features:session_position",
+        "user_book_features:session_genre_drift",
+        "user_book_features:time_since_last_action",
+        "user_book_features:is_mobile",
+        "user_book_features:is_desktop",
+        "user_book_features:is_tablet",
+        "user_book_features:session_length",
+        "user_book_features:global_pop_rank",
+        "user_book_features:trending_score",
+        "user_book_features:intra_list_diversity",
+    ]
+
+    try:
+        df = (
+            store.get_historical_features(
+                entity_df=entity_df,
+                features=feature_names
+            )
+            .to_df()
+        )
+        return df
+
+    except Exception as e:
+        logger.warning(f"Feast get_historical_features failed: {e}")
+        return pd.DataFrame()
+
+
+def get_historical_features_direct_s3(entity_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Read feature parquet directly from S3 by listing the bucket at runtime.
+    This always reflects current S3 state (no registry/cache), so you get the
+    latest feature data. Use this when you want only the parquet files that
+    exist now (e.g. after clearing old files).
+    """ 
+    bucket = FEAST_S3_BUCKET
+    prefix = "features/"
+    needed = ["user_book", "user_id", "book_id", "query_id"] + FEATURE_COLS
+    try:
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        )
+        paginator = s3.get_paginator("list_objects_v2")
+        frames = []
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents") or []:
+                key = obj["Key"]
+                if not key.endswith("user_book_features.parquet"):
+                    continue
+                buf = io.BytesIO()
+                s3.download_fileobj(bucket, key, buf)
+                buf.seek(0)
+                df = pd.read_parquet(buf)
+                if df.empty:
+                    continue
+                if "timestamp" in df.columns:
+                    df = df.dropna(subset=["timestamp"])
+                if df.empty:
+                    continue
+                df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+                frames.append(df)
+        if not frames:
+            logger.warning("No parquet files found under s3://%s/%s", bucket, prefix)
+            return pd.DataFrame()
+        combined = pd.concat(frames, ignore_index=True)
+        # Keep latest row per user_book (most recent timestamp)
+        combined = combined.sort_values("timestamp").drop_duplicates(subset=["user_book"], keep="last")
+        want = [c for c in needed if c in combined.columns]
+        if len(want) < len(needed):
+            missing = set(needed) - set(combined.columns)
+            logger.warning("Direct S3 parquet missing columns: %s", missing)
+        out = entity_df[["user_book"]].merge(combined, on="user_book", how="inner")
+        logger.info("Direct S3 read: %d parquet file(s), %d rows after merge with labels", len(frames), len(out))
+        return out
+    except Exception as e:
+        logger.warning("Direct S3 feature read failed: %s", e)
+        return pd.DataFrame()
+
+
+def train_and_save(train_df: pd.DataFrame):
+    """Train XGBoost rank:ndcg and save to S3."""
+    prefix = LTR_S3_PREFIX
+    bucket = S3_URI.replace("s3://", "").split("/")[0] if S3_URI.startswith("s3://") else S3_URI.split("/")[0]
+    if not bucket or not train_df.size:
+        logger.warning("No training data or S3_URI")
+        return
+    
+    missing = [f for f in FEATURE_COLS if f not in train_df.columns]
+    if missing:
+        logger.warning(f"Missing features: {missing[:5]}...")
+        return
+    # Sort by user_id so consecutive rows form query groups
+    train_df = train_df.sort_values("user_id").reset_index(drop=True)
+    # 80/20 train/val split by query (user_id)
+    uids = train_df["user_id"].unique()
+    np.random.seed(42)
+    np.random.shuffle(uids)
+    n = max(1, int(0.8 * len(uids)))
+    train_uids, val_uids = set(uids[:n]), set(uids[n:])
+    tr = train_df[train_df["user_id"].isin(train_uids)]
+    va = train_df[train_df["user_id"].isin(val_uids)]
+    if va.empty:
+        va = tr
+    X_tr = tr[FEATURE_COLS].fillna(0).astype(np.float32)
+    y_tr = tr["relevance"].astype(np.int32)
+    grp_tr = tr.groupby("user_id", sort=False).size().values.astype(np.uint32)
+    dtrain = xgb.DMatrix(X_tr, label=y_tr, feature_names=FEATURE_COLS)
+    dtrain.set_group(grp_tr)
+    X_va = va[FEATURE_COLS].fillna(0).astype(np.float32)
+    y_va = va["relevance"].astype(np.int32)
+    grp_va = va.groupby("user_id", sort=False).size().values.astype(np.uint32)
+    dval = xgb.DMatrix(X_va, label=y_va, feature_names=FEATURE_COLS)
+    dval.set_group(grp_va)
+    params = {
+        "objective": "rank:ndcg",
+        "eval_metric": "ndcg@10",
+        "eta": 0.05,
+        "max_depth": 8,
+        "subsample": 0.8,
+        "colsample_bytree": 0.8,
+        "min_child_weight": 1,
+        "gamma": 0.1,
+        "lambda": 1.0,
+        "tree_method": "hist",
+    }
+    bst = xgb.train(
+        params,
+        dtrain,
+        num_boost_round=500,
+        evals=[(dtrain, "train"), (dval, "val")],
+        early_stopping_rounds=50,
+        verbose_eval=50,
+    )
+    key = f"{prefix}/ltr_xgb_latest.json"
+    # XGBoost save_model() requires a path (string or PathLike), not a buffer
+    fd, tmp_path = tempfile.mkstemp(suffix=".json")
+    try:
+        os.close(fd)
+        bst.save_model(tmp_path)
+        with open(tmp_path, "rb") as f:
+            body = f.read()
+        client = boto3.client(
+            "s3",
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        )
+        client.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
+        logger.info(f"Saved LTR model to s3://{bucket}/{key}")
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def main():
+    logger.info("Building relevance labels from MongoDB...")
+    labels_df = get_relevance_labels_from_mongo()
+    print("labels_df: ", labels_df.head(5).to_string())
+    if labels_df.empty or len(labels_df) < 0:
+        logger.warning("Insufficient label data")
+        return
+    entity_df = labels_df[["user_book", "timestamp"]].copy()
+    entity_df["timestamp"] = pd.to_datetime(entity_df["timestamp"], utc=True)
+    # Use direct S3 read first so we always get current parquet files (no Feast registry cache).
+    # Feast can serve stale paths after you delete old parquet files; direct S3 lists the bucket at runtime.
+    logger.info("Loading historical features from S3 (direct list for latest data)...")
+    features_df = get_historical_features_direct_s3(entity_df)
+    if features_df.empty:
+        logger.info("Direct S3 empty; falling back to Feast offline store...")
+        features_df = get_historical_features_from_feast(entity_df)
+    if features_df.empty:
+        logger.warning("No features from direct S3 or Feast; ensure parquet files exist under s3://%s/features/", FEAST_S3_BUCKET)
+        return
+    # Merge labels with features on user_book
+    rename = {c: c.replace("user_book_features:", "") for c in features_df.columns if c.startswith("user_book_features:")}
+    features_df = features_df.rename(columns=rename)
+    features_df.dropna(inplace=True)
+    print("features_df: ", features_df.head(5).to_string())
+    if "user_book" not in features_df.columns:
+        logger.warning("Feast output missing user_book column")
+        return
+    train_df = features_df.merge(
+        labels_df[["user_book", "user_id", "relevance"]],
+        on="user_book",
+        how="inner",
+        suffixes=("", "_label"),
+    )
+    # Merge can create user_id_label when both sides have user_id; keep a single user_id
+    if "user_id_label" in train_df.columns:
+        train_df = train_df.drop(columns=["user_id_label"])
+    if "user_id" not in train_df.columns:
+        train_df["user_id"] = train_df["user_book"].str.split("_", n=1).str[0]
+    if train_df.empty or "relevance" not in train_df.columns:
+        logger.warning("No merged training data")
+        return
+    logger.info(f"Training on {len(train_df)} rows, {train_df['user_id'].nunique()} queries")
+    train_and_save(train_df)
+    logger.info("LTR training done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model_training_service/ltr_train/requirements.txt
+++ b/src/model_training_service/ltr_train/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+numpy
+xgboost
+pymongo
+boto3
+feast
+s3fs
+redis

--- a/src/model_training_service/popularity_train/Dockerfile
+++ b/src/model_training_service/popularity_train/Dockerfile
@@ -2,12 +2,13 @@ FROM python:3.10
 
 WORKDIR /app
 
-COPY popularity_train.py .
 COPY requirements.txt .
 COPY entrypoint.sh .
 
 RUN chmod +x entrypoint.sh \
     && pip install --upgrade pip \
     && pip install -r requirements.txt
+
+COPY popularity_train.py .
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/model_training_service/sasrec_train/Dockerfile
+++ b/src/model_training_service/sasrec_train/Dockerfile
@@ -2,14 +2,15 @@ FROM python:3.10
 
 WORKDIR /app
 
-COPY sasrec_model.py .
-COPY sasrec_data.py .
-COPY sasrec_train.py .
 COPY requirements.txt .
 COPY entrypoint.sh .
 
 RUN chmod +x entrypoint.sh \
     && pip install --upgrade pip \
     && pip install -r requirements.txt
+
+COPY sasrec_model.py .
+COPY sasrec_data.py .
+COPY sasrec_train.py .
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/model_training_service/sasrec_train/sasrec_data.py
+++ b/src/model_training_service/sasrec_train/sasrec_data.py
@@ -55,7 +55,6 @@ def load_sessions_for_training(
     if days_back is None:
         days_back = int(os.getenv("SASREC_DAYS_BACK", "30"))
     
-    # assume `timestamp` is a MongoDB Date field
     cutoff = datetime.utcnow() - timedelta(days=days_back)
     
     logging.info(f"Loading sessions from MongoDB (last {days_back} days, cutoff: {cutoff})")
@@ -99,7 +98,6 @@ def load_sessions_for_training(
                 },
             }
         },
-        # optional, or remove this entirely
         {"$match": {"last_timestamp": {"$gte": cutoff}}},
     ]
 

--- a/src/recommendation_service/Dockerfile
+++ b/src/recommendation_service/Dockerfile
@@ -1,7 +1,15 @@
+# Build from repo root so feature_repo is in context:
+#   docker build -f src/recommendation_service/Dockerfile -t recommendation-service .
 FROM python:3.9-slim
 WORKDIR /app
-COPY requirements.txt .
+
+COPY src/recommendation_service/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+COPY src/recommendation_service/ .
+
+# Feast feature repo (for FEAST_REPO_PATH, materialize_incremental, get_online_features)
+COPY feast_feature_store/feature_repo /app/feature_repo
+ENV FEAST_REPO_PATH=/app/feature_repo
+
 EXPOSE 8001
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/src/recommendation_service/collaborative_filtering.py
+++ b/src/recommendation_service/collaborative_filtering.py
@@ -39,5 +39,5 @@ async def recommend_als_books(user_id: str, top_k: int = 50) -> Tuple[List[str],
     top_indices = np.argsort(scores)[::-1][:top_k]
     recommended_books = book_ids[top_indices]
     recommended_scores = scores[top_indices]
-    print(f"2. ALS Recommendations for user {user_id}: {recommended_books} with scores {recommended_scores}")
+    print(f"2. ALS Recommendations for user {user_id}: {recommended_books} with scores {recommended_scores} with top_k {top_k}")
     return recommended_books.tolist(), recommended_scores.tolist()

--- a/src/recommendation_service/content_based_recommendation.py
+++ b/src/recommendation_service/content_based_recommendation.py
@@ -31,5 +31,5 @@ async def dense_vector_recommendation(user_id: str, top_k: int = 50) -> Tuple[Li
         if book_id is not None and score is not None:
             book_ids.append(book_id)
             scores.append(score)
-    print(f"1. CB Recommendations for user {user_id}: {book_ids} with scores {scores}")
+    print(f"1. CB Recommendations for user {user_id}: {book_ids} with scores {scores} with top_k {top_k}")
     return book_ids, scores

--- a/src/recommendation_service/graph_recommendation.py
+++ b/src/recommendation_service/graph_recommendation.py
@@ -225,5 +225,5 @@ def graph_recommend_books(user_id: str, top_k: int = 50):
 
     # sort by score desc, take top_k
     book_scores.sort(key=lambda x: x[1], reverse=True)
-    print(f"3. Graph Recommendations for user {user_id}: {book_scores[:top_k]}")
+    print(f"3. Graph Recommendations for user {user_id}: {book_scores[:top_k]} with top_k {top_k}")
     return book_scores[:top_k]

--- a/src/recommendation_service/ltr_ranking.py
+++ b/src/recommendation_service/ltr_ranking.py
@@ -1,0 +1,154 @@
+"""
+Stage 4: Learning-to-Rank (LTR) with XGBoost LambdaRank.
+Ranks candidates by predicted engagement using a model trained with rank:ndcg objective.
+Expects feature matrix from Feast (29 features); returns sorted (book_ids, scores).
+"""
+import os
+import tempfile
+import logging
+from typing import Tuple, List, Optional
+import numpy as np
+import boto3
+from io import BytesIO
+import xgboost as xgb
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# 29 features in same order as feature_service / Feast user_book_features view
+LTR_FEATURE_NAMES = [
+    "retrieval_0", "retrieval_1", "retrieval_2", "retrieval_3", "retrieval_4", "retrieval_5",
+    "genre_match_count", "author_match", "language_match",
+    "avg_rating", "user_rating", "avg_rating_diff", "rating_count", "user_pref_strength",
+    "friend_reads_count", "friend_avg_rating", "author_following", "mutual_likes", "social_proximity",
+    "session_position", "session_genre_drift", "time_since_last_action",
+    "is_mobile", "is_desktop", "is_tablet", "session_length",
+    "global_pop_rank", "trending_score", "intra_list_diversity",
+]
+
+# Optional: strip Feast prefix from column names
+FEAST_PREFIX = "user_book_features:"
+
+
+def _load_model():
+    """Load XGBoost LTR model from S3 (trained with rank:ndcg). Returns None if unavailable."""
+    s3_uri = os.getenv("S3_URI", "").rstrip("/")
+    if not s3_uri or "s3://" not in s3_uri:
+        bucket = s3_uri or ""
+    else:
+        bucket = s3_uri.replace("s3://", "").split("/")[0]
+    prefix = os.getenv("LTR_S3_PREFIX", "LTR_Train")
+    key = f"{prefix}/ltr_xgb_latest.json"
+    if not bucket:
+        logger.debug("LTR: S3_URI not set")
+        return None
+    try:
+        client = boto3.client(
+            "s3",
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        )
+        obj = client.get_object(Bucket=bucket, Key=key)
+        body = obj["Body"].read()
+        fd, path = tempfile.mkstemp(suffix=".json")
+        try:
+            os.write(fd, body)
+            os.close(fd)
+            fd = None
+            bst = xgb.Booster()
+            bst.load_model(path)
+            logger.info("LTR: loaded XGBoost model from S3")
+            return bst
+        finally:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if os.path.exists(path):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+    except Exception as e:
+        logger.warning(f"LTR: model load failed: {e}")
+        return None
+
+
+# Lazy-loaded singleton
+_ltr_model = None
+
+
+def _get_model():
+    global _ltr_model
+    if _ltr_model is None:
+        _ltr_model = _load_model()
+    return _ltr_model
+
+
+def _normalize_feature_df(df):
+    """Ensure DataFrame has columns matching LTR_FEATURE_NAMES (strip Feast prefix if present)."""
+    df = df.copy()
+    rename = {}
+    for c in df.columns:
+        if c.startswith(FEAST_PREFIX):
+            rename[c] = c[len(FEAST_PREFIX):]
+    if rename:
+        df = df.rename(columns=rename)
+    return df
+
+
+def _extract_book_ids_from_user_book(user_id: str, df) -> List[str]:
+    """Get book_id from user_book column (format user_id_book_id)."""
+    if "user_book" not in df.columns:
+        return []
+    book_ids = []
+    for v in df["user_book"]:
+        s = str(v)
+        if "_" in s and s.startswith(user_id):
+            book_ids.append(s[len(user_id) + 1:].strip())
+        elif "_" in s:
+            book_ids.append(s.split("_", 1)[1].strip())
+        else:
+            book_ids.append(s)
+    return book_ids
+
+
+def rank_candidates(
+    user_id: str,
+    feature_df,
+    top_k: int = 100,
+) -> Tuple[List[str], List[float]]:
+    """
+    Rank candidates using XGBoost LTR model (LambdaRank/NDCG).
+    feature_df: DataFrame from Feast get_online_features (must include user_book + 29 features).
+    Returns (book_ids, scores) sorted by score descending.
+    """
+    if feature_df is None or feature_df.empty:
+        return [], []
+    bst = _get_model()
+    if bst is None:
+        return [], []
+    df = _normalize_feature_df(feature_df)
+    missing = [f for f in LTR_FEATURE_NAMES if f not in df.columns]
+    if missing:
+        logger.warning(f"LTR: missing features {missing[:5]}...")
+        return [], []
+    X = df[LTR_FEATURE_NAMES].fillna(0).astype(np.float32)
+    book_ids = _extract_book_ids_from_user_book(user_id, df)
+    if len(book_ids) != len(X):
+        logger.warning("LTR: book_id count != feature row count")
+        return [], []
+    try:
+        dmat = xgb.DMatrix(X, feature_names=LTR_FEATURE_NAMES)
+        scores = bst.predict(dmat)
+    except Exception as e:
+        logger.warning(f"LTR predict failed: {e}")
+        return [], []
+    idx = np.argsort(-np.asarray(scores))
+    top_idx = idx[:top_k]
+    out_ids = [book_ids[i] for i in top_idx]
+    out_scores = [float(scores[i]) for i in top_idx]
+    print(f"LTR ranking for user {user_id}: {out_ids} with scores {out_scores} with top_k {top_k}")
+    return out_ids, out_scores

--- a/src/recommendation_service/main.py
+++ b/src/recommendation_service/main.py
@@ -1,23 +1,32 @@
-from datetime import datetime 
+from datetime import datetime, timedelta
 import os
+import json
 import redis
 import httpx
 import jwt
 import random
 import asyncio
 import logging
+from pymongo import MongoClient
+from feast import FeatureStore
+import pandas as pd
 from typing import Optional, List, Dict, Any, Tuple
-from fastapi import FastAPI, Depends, Security, HTTPException, Query, Request
+from fastapi import FastAPI, Depends, Security, HTTPException, Query, Request, Header
 from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from collections import defaultdict
 import content_based_recommendation as cbr
+from content_based_recommendation import book_index as pinecone_book_index
 import collaborative_filtering as cf
+import numpy as np 
 from graph_recommendation import graph_recommend_books
 from sasrec_inference import recommend_for_session
 from popularity_recommendation import get_popularity_recommendations, get_s3_popularity_fallback
 from linucb_inference import linucb_ranker
-from feature_engineering.feature_service import feature_service
+from feature_engineering.feature_service import feature_service, get_feast_repo_path
+from ltr_ranking import rank_candidates as ltr_rank_candidates
+
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
@@ -38,6 +47,20 @@ headers = {
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
 
+# Internal API key for background pods (set INTERNAL_API_KEY env)
+INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "bibliophileai")
+
+
+def verify_internal_key(x_internal_key: Optional[str] = Header(None, alias="X-Internal-Key")):
+    if not INTERNAL_API_KEY or x_internal_key != INTERNAL_API_KEY:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return True
+
+
+class RefreshBody(BaseModel):
+    user_id: str
+
+
 app = FastAPI()
 
 app.add_middleware(
@@ -50,6 +73,64 @@ app.add_middleware(
 
 redis_client = redis.from_url(os.environ["REDIS_URL"])
 combined_scores_map = defaultdict(dict)
+
+# Per-user recommendation cache: always serve from cache; background pods update on events.
+RECOMMEND_CACHE_KEY_PREFIX = "recommend:combined:"
+RECOMMEND_CACHE_TTL_SECONDS = 365 * 24 * 3600  # 1 year
+
+
+def _cache_key(user_id: str) -> str:
+    return f"{RECOMMEND_CACHE_KEY_PREFIX}{user_id}"
+
+
+def get_cached_recommendations(user_id: str) -> Optional[Dict[str, Any]]:
+    """Return cached combined recommendations (by category) or None if miss. Excludes Trending Now (filled from global Redis)."""
+    try:
+        raw = redis_client.get(_cache_key(user_id))
+        if not raw:
+            return None
+        return json.loads(raw)
+    except Exception as e:
+        logger.warning(f"Cache get failed for user {user_id}: {e}")
+        return None
+
+def set_cached_recommendations(user_id: str, payload: Dict[str, Any]) -> None:
+    """Store full combined recommendations and set 1-year TTL."""
+    try:
+        key = _cache_key(user_id)
+        redis_client.setex(key, RECOMMEND_CACHE_TTL_SECONDS, json.dumps(payload))
+        logger.info(f"Cache set for user {user_id}, {len(payload.get('categories', []))} categories")
+    except Exception as e:
+        logger.warning(f"Cache set failed for user {user_id}: {e}")
+
+
+def update_cached_category(
+    user_id: str,
+    category_name: str,
+    category_payload: Dict[str, Any],
+) -> None:
+    """
+    Update one category in the user's cached recommendations (used by background pods).
+    category_payload: {"category": str, "description": str, "books": [...]}
+    If cache miss, creates a cache with only this category.
+    """
+    try:
+        key = _cache_key(user_id)
+        raw = redis_client.get(key)
+        if raw:
+            payload = json.loads(raw)
+            categories = list(payload.get("categories") or [])
+        else:
+            categories = []
+        # Replace or append category by name
+        categories = [c for c in categories if c.get("category") != category_name]
+        categories.append(category_payload)
+        payload = {"categories": categories}
+        redis_client.setex(key, RECOMMEND_CACHE_TTL_SECONDS, json.dumps(payload))
+        logger.info(f"Cache updated category '{category_name}' for user {user_id}")
+    except Exception as e:
+        logger.warning(f"Cache update category failed for user {user_id}: {e}")
+
 
 def decode_access_token(token: str):
     return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
@@ -77,16 +158,140 @@ async def get_current_user(token: str = Security(oauth2_scheme)):
         raise credentials_exception
     return user
 
+# Supabase/books request timeout (avoid 500 on slow or unreachable Supabase)
+BOOKS_FETCH_TIMEOUT = float(os.getenv("BOOKS_FETCH_TIMEOUT", "60.0"))
+
 async def get_books_by_ids(ids: List[str]):
     if not ids:
         return []
-    async with httpx.AsyncClient() as client:
-        idlist = ",".join([f'"{bid}"' for bid in ids])
-        fields = "id,title,authors,categories,thumbnail_url,download_link"
-        url = f"{SUPABASE_URL}/rest/v1/books?select={fields}&id=in.({idlist})"
-        resp = await client.get(url, headers=headers)
-        resp.raise_for_status()
-        return resp.json()
+    try:
+        async with httpx.AsyncClient(timeout=BOOKS_FETCH_TIMEOUT) as client:
+            idlist = ",".join([f'"{bid}"' for bid in ids])
+            fields = "id,title,authors,categories,thumbnail_url,download_link"
+            url = f"{SUPABASE_URL}/rest/v1/books?select={fields}&id=in.({idlist})"
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+    except (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.ConnectError) as e:
+        logger.warning(f"Books fetch failed (timeout/connect): {e}. Check SUPABASE_URL and network.")
+        return []
+    except Exception as e:
+        logger.warning(f"Books fetch failed: {e}")
+        return []
+
+
+async def get_user_preferred_genres(user_id: str) -> List[str]:
+    """Fetch user's preferred genres from Supabase user_preferences."""
+    try:
+        async with httpx.AsyncClient() as client:
+            url = f"{SUPABASE_URL}/rest/v1/user_preferences"
+            params = {"user_id": f"eq.{user_id}", "select": "genres"}
+            resp = await client.get(url, headers=headers, params=params)
+            resp.raise_for_status()
+            rows = resp.json()
+            if not rows or not isinstance(rows, list):
+                return []
+            genres = rows[0].get("genres") if rows else []
+            return list(genres) if isinstance(genres, (list, tuple)) else []
+    except Exception as e:
+        logger.warning(f"Failed to fetch user preferences: {e}")
+        return []
+
+async def _get_trending_now_category(top_k: int = 50) -> Dict[str, Any]:
+    """
+    Build 'Trending Now' category from global Redis key (popularity:trending:multi)
+    populated by model_training_service/popularity_train. Same for all users; not stored per user.
+    """
+    pop_book_ids, pop_scores = await get_popularity_recommendations("", window="multi", top_k=top_k)
+    if not pop_book_ids:
+        return {"category": "Trending Now", "description": "Popular books right now", "books": []}
+    books_list = await get_books_by_ids(pop_book_ids)
+    books_dict = {str(b.get("id") or b.get("_id")): b for b in books_list}
+    books = []
+    for bid, score in zip(pop_book_ids, pop_scores):
+        if bid in books_dict:
+            b = books_dict[bid].copy()
+            b["score"] = float(score)
+            books.append(b)
+    return {"category": "Trending Now", "description": "Popular books right now", "books": books}
+
+
+
+async def get_books_by_genre(genre: str, top_k: int = 25) -> Tuple[List[str], List[float]]:
+    """
+    Genre-based recommendations using Pinecone: get seed books in this genre from Supabase,
+    compute a genre centroid from their vectors, then query Pinecone for similar books.
+    Returns (book_ids, similarity_scores).
+    """
+    try:
+        # 1. Get seed book IDs in this genre from Supabase
+        async with httpx.AsyncClient() as client:
+            contains_val = 'cs.{"' + genre.replace('"', '\\"') + '"}'
+            params = {"select": "id", "categories": contains_val, "limit": 50}
+            resp = await client.get(f"{SUPABASE_URL}/rest/v1/books", headers=headers, params=params)
+            resp.raise_for_status()
+            books = resp.json()
+        if not books:
+            return [], []
+        seed_ids = [str(b["id"]) for b in books if b.get("id")]
+        if not seed_ids:
+            return [], []
+
+        # 2. Fetch seed book vectors from Pinecone and compute genre centroid
+        fetch_result = pinecone_book_index.fetch(ids=seed_ids, namespace="__default__")
+        vectors = getattr(fetch_result, "vectors", None) or {}
+        vec_list = []
+        for bid in seed_ids:
+            rec = vectors.get(bid)
+            if rec and getattr(rec, "values", None):
+                vec_list.append(np.array(list(rec.values)))
+        if not vec_list:
+            # No vectors in Pinecone for this genre; fallback to seed IDs with uniform score
+            return seed_ids[:top_k], [1.0] * min(len(seed_ids), top_k)
+        centroid = np.mean(vec_list, axis=0)
+
+        # 3. Query Pinecone for books similar to the genre centroid
+        query_result = pinecone_book_index.query(
+            vector=centroid.tolist(),
+            top_k=top_k,
+            namespace="__default__",
+            include_metadata=False,
+        )
+        book_ids = []
+        scores = []
+        for m in (query_result.matches or []):
+            bid = m.get("_id") or m.get("id") if hasattr(m, "get") else (getattr(m, "id", None) or getattr(m, "_id", None))
+            score = m.get("score") if hasattr(m, "get") else getattr(m, "score", None)
+            if bid is not None:
+                book_ids.append(str(bid))
+                scores.append(float(score) if score is not None else 1.0)
+        return book_ids, scores
+    except Exception as e:
+        logger.warning(f"Pinecone genre similarity failed for {genre}: {e}")
+        return [], []
+
+
+def _get_currently_reading_book_ids_sync(user_id: str, limit: int = 20) -> List[str]:
+    """
+    Books the user has started reading (has at least one page_turn event).
+    Returns list of book ids, most recently turned page first.
+    """
+    try:
+        client = MongoClient(os.environ["MONGO_URI"])
+        col = client["click_stream"]["events"]
+        pipeline = [
+            {"$match": {"user_id": user_id, "event_type": "page_turn"}},
+            {"$sort": {"received_at": -1}},
+            {"$group": {"_id": "$item_id", "last_at": {"$first": "$received_at"}}},
+            {"$sort": {"last_at": -1}},
+            {"$limit": limit},
+            {"$project": {"_id": 1}}
+        ]
+        return [doc["_id"] for doc in col.aggregate(pipeline)]
+    except Exception as e:
+        logger.warning(f"MongoDB currently reading failed: {e}")
+        return []
+
 
 @app.get("/api/v1/recommend/graph")
 async def recommend_graph(current_user: dict = Depends(get_current_user)):
@@ -168,103 +373,456 @@ async def recommend_combined(
     current_user: dict = Depends(get_current_user),
     request: Request = None
 ):
+    """
+    Returns recommendations grouped by algorithm/category in Netflix-style format.
+    Always served from Redis cache (1-year TTL). On cache miss, computes once and stores.
+    """
     user_id = str(current_user["id"])
 
-    # 1. Get IDs and relevance scores from ALL recommenders (5 total)
-    print(f"Generating recommendations for user {user_id}")
+    # Always try cache first (cache does not store Trending Now; we inject from global Redis)
+    cached = get_cached_recommendations(user_id)
+    if cached is not None:
+        logger.info(f"Serving combined recommendations from cache for user {user_id}")
+        trending = await _get_trending_now_category(top_k=50)
+        categories_list = list(cached.get("categories") or [])
+        categories_list = [c for c in categories_list if c.get("category") != "Trending Now"]
+        if trending.get("books"):
+            categories_list.append(trending)
+        cached["categories"] = categories_list
+        print(f"Serving combined recommendations from cache for user {user_id}: {cached}")
+        return cached
+
+    # Cache miss: compute full recommendations, then store and return
+    loop = asyncio.get_running_loop()
+    currently_reading_ids = await loop.run_in_executor(
+        None, _get_currently_reading_book_ids_sync, user_id, 20
+    )
+    print(f"Cache miss: generating recommendations for user {user_id}")
     
     # Content-based
-    cb_book_ids, cb_scores = await cbr.dense_vector_recommendation(user_id, top_k=100)
+    cb_book_ids, cb_scores = await cbr.dense_vector_recommendation(user_id, top_k=50)
     
     # Collaborative filtering (ALS)
-    als_book_ids, cf_scores = await cf.recommend_als_books(user_id, top_k=100)
+    als_book_ids, cf_scores = await cf.recommend_als_books(user_id, top_k=50)
     
     # Graph-based
     loop = asyncio.get_running_loop()
-    graph_results = await loop.run_in_executor(None, graph_recommend_books, user_id, 100)
+    graph_results = await loop.run_in_executor(None, graph_recommend_books, user_id, 50)
     graph_book_ids = [bid for bid, _ in graph_results]
     graph_scores = [score for _, score in graph_results]
     
     # Session-based (SASRec)
-    session_book_ids, session_scores = recommend_for_session(user_id, top_k=100)
+    session_book_ids, session_scores = recommend_for_session(user_id, top_k=50)
     
-    # Popularity-based (NEW: calls popularity service endpoint)
-    pop_book_ids, pop_scores = await get_popularity_recommendations(user_id, top_k=100)
+    # Popularity-based
+    pop_book_ids, pop_scores = await get_popularity_recommendations(user_id, top_k=50)
+    
     print(f"Got {len(cb_book_ids)} CB, {len(als_book_ids)} ALS, {len(graph_book_ids)} Graph, "
           f"{len(session_book_ids)} Session, {len(pop_book_ids)} Popularity books")
-    
+
+    # LinUCB: merge all candidates and rank with contextual bandit
     all_candidates = list(set(
-        cb_book_ids + als_book_ids + graph_book_ids + 
+        cb_book_ids + als_book_ids + graph_book_ids +
         session_book_ids + pop_book_ids
     ))
-    print(f"Combined {len(all_candidates)} unique candidates from 5 sources")
-
+    print(f"All candidates: {all_candidates} with length {len(all_candidates)}")
     linucb_book_ids, linucb_scores = linucb_ranker.get_linucb_ranked(all_candidates, user_id)
 
-    # 2. Take equal share from each source
-    target_total = 1000
-    num_sources = 6  # CB + ALS + Graph + Session + Popularity + LinUCB
-    target_each = max(1, target_total // num_sources)
-    
-    cb_final = cb_book_ids[:target_each]
-    cb_final_scores = cb_scores[:target_each]
-    
-    als_final = als_book_ids[:target_each]
-    als_final_scores = cf_scores[:target_each]
-    
-    graph_final = graph_book_ids[:target_each]
-    graph_final_scores = graph_scores[:target_each]
-    
-    session_final = session_book_ids[:target_each]
-    session_final_scores = session_scores[:target_each]
+    # Build combined_scores_map for feature engineering (Feast integration)
+    combined_scores_map.clear()
+    add_scores(cb_book_ids[:100], cb_scores[:100] if len(cb_scores) >= 100 else cb_scores, "content")
+    add_scores(als_book_ids[:100], cf_scores[:100] if len(cf_scores) >= 100 else cf_scores, "als")
+    add_scores(graph_book_ids[:100], graph_scores[:100] if len(graph_scores) >= 100 else graph_scores, "graph")
+    add_scores(session_book_ids[:100], session_scores[:100] if len(session_scores) >= 100 else session_scores, "session")
+    add_scores(pop_book_ids[:100], pop_scores[:100] if len(pop_scores) >= 100 else pop_scores, "popularity")
+    add_scores(linucb_book_ids[:100], linucb_scores[:100] if len(linucb_scores) >= 100 else linucb_scores, "linucb")
 
-    pop_final = pop_book_ids[:target_each]
-    pop_final_scores = pop_scores[:target_each]
+    # Feast integration: engineer features and store to feature store (S3)
+    feature_entities_from_batch = None
+    candidate_ids = list(combined_scores_map.keys())
+    try:
+        session_context = await build_session_context(current_user, request)
+        if candidate_ids:
+            feature_entities_from_batch = await feature_service.engineer_features_batch(
+                user_id, candidate_ids, combined_scores_map, session_context
+            )
+            logger.info(f"Feast: stored features for {len(candidate_ids)} user-book pairs")
+            # Push offline store (S3) to online store (Redis) so get_online_features sees latest data
+            try:
+                await loop.run_in_executor(None, feature_service.materialize_offline_to_online)
+            except Exception as mat_e:
+                logger.warning(f"Feast materialize_incremental failed (non-fatal): {mat_e}")
+    except Exception as e:
+        logger.warning(f"Feast feature engineering failed (non-fatal): {e}")
 
-    linucb_final = linucb_book_ids[:target_each]
-    linucb_final_scores = linucb_scores[:target_each]
+    # Optional: retrieve features from Feast online store for LTR ranking
+    feast_features_df = None
+    try:
+        feast_features_df = get_feast_online_features(user_id, candidate_ids or [])
+    except Exception as e:
+        logger.debug(f"Feast get_online_features skipped: {e}")
 
-    # 3. Combine all
-    add_scores(cb_final, cb_final_scores, "content")
-    add_scores(als_final, als_final_scores, "als")
-    add_scores(graph_final, graph_final_scores, "graph")
-    add_scores(session_final, session_final_scores, "session")
-    add_scores(pop_final, pop_final_scores, "popularity")
-    add_scores(linucb_final, linucb_final_scores, "linucb")
-    print(f"Combined unique book IDs before shuffling: {len(combined_scores_map)}")
+    # Use in-memory features for LTR when online store returns all None (e.g. materialize wrote 0 keys)
+    if feast_features_df is not None and not feast_features_df.empty:
+        feature_cols = [c for c in feast_features_df.columns if c != "user_book" and not c.startswith("event_timestamp")]
+        if feature_cols and feast_features_df[feature_cols].isna().all().all():
+            if feature_entities_from_batch:
+                feast_features_df = pd.DataFrame(feature_entities_from_batch)
+                logger.info("LTR using in-memory features (Feast online store had no values)")
+            else:
+                feast_features_df = None
+                print("feature_entities_from_batch is None")
 
-    all_book_ids = list(combined_scores_map.keys())
-    session_context = await build_session_context(current_user, request)
-    features = await feature_service.engineer_features_batch(
-        user_id, all_book_ids, combined_scores_map, session_context
-    )
-    print(f"Engineered features for {len(features)} books")
-    print("Features:", features)
-    # 4. Shuffle for serendipity
-    all_book_ids = list(combined_scores_map.keys())
-    random.shuffle(all_book_ids)
+    # Learning-to-Rank: score candidates with XGBoost LambdaRank, add "Top Picks" category
+    ltr_book_ids, ltr_scores = [], []
+    if feast_features_df is not None and not feast_features_df.empty:
+        try:
+            ltr_book_ids, ltr_scores = ltr_rank_candidates(user_id, feast_features_df, top_k=100)
+            if ltr_book_ids:
+                logger.info(f"LTR ranked {len(ltr_book_ids)} books for user {user_id}")
+        except Exception as e:
+            logger.warning(f"LTR ranking failed (non-fatal): {e}")
 
-    final_ids = all_book_ids[:target_total]
+    # 2. Fetch book metadata for each category (order: Continue Reading, then per-genre, then algorithms + Top Picks)
+    categories = {}
+    if currently_reading_ids:
+        categories["Continue Reading"] = {
+            "book_ids": currently_reading_ids,
+            "scores": [1.0] * len(currently_reading_ids),
+            "description": "Pick up where you left off"
+        }
+    categories["Content-Based Recommendations"] = {
+        "book_ids": cb_book_ids,
+        "scores": cb_scores,
+        "description": "Books similar to your preferences"
+    }
+    categories["Collaborative Filtering"] = {
+        "book_ids": als_book_ids,
+        "scores": cf_scores,
+        "description": "Readers with similar tastes also enjoyed"
+    }
+    categories["Social Recommendations"] = {
+        "book_ids": graph_book_ids,
+        "scores": graph_scores,
+        "description": "Based on your social network"
+    }
+    categories["Session-Based"] = {
+        "book_ids": session_book_ids,
+        "scores": session_scores,
+        "description": "Based on your recent activity"
+    }
+    categories["Trending Now"] = {
+        "book_ids": pop_book_ids,
+        "scores": pop_scores,
+        "description": "Popular books right now"
+    }
+    categories["For You (LinUCB)"] = {
+        "book_ids": linucb_book_ids,
+        "scores": linucb_scores,
+        "description": "Personalized picks with exploration"
+    }
+    # Top Picks from LTR (always set category; empty when LTR has no results)
+    categories["Top Picks"] = {
+        "book_ids": ltr_book_ids,
+        "scores": ltr_scores,
+        "description": "Recommended for you by our ranking model"
+    }
+
+    # Fetch all unique books (include LinUCB, continue reading, genre rows, Top Picks)
+    all_book_ids = list(set(
+        cb_book_ids + als_book_ids + graph_book_ids +
+        session_book_ids + pop_book_ids + linucb_book_ids +
+        currently_reading_ids + ltr_book_ids
+    ))
+    books_dict = {book["id"]: book for book in await get_books_by_ids(all_book_ids)}
     
-    # 6. Fetch metadata and attach scores
-    books = await get_books_by_ids(list(final_ids))
+    # Build category-based recommendations
+    category_recommendations = []
+    for category_name, category_data in categories.items():
+        if not category_data["book_ids"]:
+            continue
+            
+        books = []
+        for book_id, score in zip(category_data["book_ids"], category_data["scores"]):
+            if book_id in books_dict:
+                book = books_dict[book_id].copy()
+                book["score"] = float(score)
+                books.append(book)
+        
+        if books:
+            category_recommendations.append({
+                "category": category_name,
+                "description": category_data["description"],
+                "books": books
+            })
     
-    recommendations = []
-    
-    for book in books:
-        bid = book.get("id") or book.get("_id")
-        if bid in combined_scores_map:
-            book["scores"] = combined_scores_map[bid]
-            book["source"] = list(combined_scores_map[bid].keys())
-        recommendations.append(book)
-    
-    print(f"Returning {len(recommendations)} final recommendations")
-    return {"recommendations": recommendations}
+    payload = {"categories": category_recommendations}
+    # Don't store Trending Now per user; it always comes from global Redis (popularity:trending:*)
+    to_cache = {"categories": [c for c in category_recommendations if c.get("category") != "Trending Now"]}
+    set_cached_recommendations(user_id, to_cache)
+    print(f"Returning {len(category_recommendations)} categories with recommendations")
+    return payload
 
 
 def add_scores(book_ids, scores, source_name):
     for bid, score in zip(book_ids, scores):
         combined_scores_map[bid][f"{source_name}_score"] = float(score)
+
+
+def _build_category_payload(
+    category_name: str,
+    description: str,
+    book_ids: List[str],
+    scores: List[float],
+    books_dict: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build one category object for cache: {category, description, books} with full book objects + score."""
+    books = []
+    for bid, score in zip(book_ids, scores):
+        if bid in books_dict:
+            b = books_dict[bid].copy()
+            b["score"] = float(score)
+            books.append(b)
+    return {"category": category_name, "description": description, "books": books}
+
+
+# ---------- Internal refresh endpoints (called by background pods) ----------
+
+
+@app.post("/internal/recommend/refresh-content-based")
+async def internal_refresh_content_based(
+    body: RefreshBody,
+    _: bool = Depends(verify_internal_key),
+):
+    """
+    Run content-based recommendation and update cache. Call when user preferences (genre/author) change.
+    """
+    user_id = body.user_id
+    try:
+        cb_book_ids, cb_scores = await cbr.dense_vector_recommendation(user_id, top_k=50)
+        if not cb_book_ids:
+            update_cached_category(
+                user_id,
+                "Content-Based Recommendations",
+                _build_category_payload(
+                    "Content-Based Recommendations",
+                    "Books similar to your preferences",
+                    [], [], {},
+                ),
+            )
+            return {"status": "ok", "category": "Content-Based Recommendations", "count": 0}
+        # Write features to S3 for LTR training (content_score only for this refresh)
+        try:
+            scores_map = defaultdict(dict)
+            for bid, score in zip(cb_book_ids, cb_scores):
+                scores_map[bid]["content_score"] = float(score)
+                scores_map[bid].setdefault("als_score", 0.0)
+                scores_map[bid].setdefault("graph_score", 0.0)
+                scores_map[bid].setdefault("session_score", 0.0)
+                scores_map[bid].setdefault("popularity_score", 0.0)
+                scores_map[bid].setdefault("linucb_score", 0.5)
+            _ = await feature_service.engineer_features_batch(
+                user_id, cb_book_ids, dict(scores_map), _minimal_session_context()
+            )
+            logger.info(f"Refresh content-based: wrote features to S3 for {len(cb_book_ids)} books")
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, feature_service.materialize_offline_to_online)
+            except Exception as mat_e:
+                logger.warning(f"Feast materialize_incremental failed (non-fatal): {mat_e}")
+        except Exception as e:
+            logger.warning(f"Refresh content-based: feature write to S3 failed (non-fatal): {e}")
+        books_list = await get_books_by_ids(cb_book_ids)
+        books_dict = {str(b.get("id") or b.get("_id")): b for b in books_list}
+        payload = _build_category_payload(
+            "Content-Based Recommendations",
+            "Books similar to your preferences",
+            cb_book_ids, cb_scores, books_dict,
+        )
+        update_cached_category(user_id, "Content-Based Recommendations", payload)
+        return {"status": "ok", "category": "Content-Based Recommendations", "count": len(payload["books"])}
+    except Exception as e:
+        logger.exception(f"Refresh content-based failed for {user_id}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/internal/recommend/refresh-on-logout")
+async def internal_refresh_on_logout(
+    body: RefreshBody,
+    _: bool = Depends(verify_internal_key),
+):
+    """
+    Run collaborative_filtering, SASRec, LinUCB, and currently-reading; update cache.
+    Call when user logs out (so next login gets fresh CF/session/LinUCB/continue-reading).
+    """
+    user_id = body.user_id
+    loop = asyncio.get_running_loop()
+    try:
+        # Collaborative Filtering
+        als_book_ids, cf_scores = await cf.recommend_als_books(user_id, top_k=50)
+        all_book_ids = list(als_book_ids)
+        # Session-based (SASRec)
+        session_book_ids, session_scores = recommend_for_session(user_id, top_k=50)
+        all_book_ids.extend(session_book_ids)
+        # Currently reading
+        currently_reading_ids = await loop.run_in_executor(
+            None, _get_currently_reading_book_ids_sync, user_id, 20
+        )
+        all_book_ids.extend(currently_reading_ids)
+        # LinUCB needs candidates: use ALS + session + currently_reading
+        linucb_candidates = list(set(als_book_ids + session_book_ids + currently_reading_ids))
+        linucb_book_ids, linucb_scores = linucb_ranker.get_linucb_ranked(linucb_candidates, user_id)
+        all_book_ids.extend(linucb_book_ids)
+        candidate_ids = list(set(all_book_ids))
+
+        # Write features to S3 for LTR training (from ALS, session, LinUCB, continue-reading)
+        feature_entities_from_batch = None
+        try:
+            scores_map = defaultdict(dict)
+            for bid, score in zip(als_book_ids, cf_scores):
+                scores_map[bid]["als_score"] = float(score)
+            for bid, score in zip(session_book_ids, session_scores):
+                scores_map[bid]["session_score"] = float(score)
+            for bid, score in zip(linucb_book_ids, linucb_scores):
+                scores_map[bid]["linucb_score"] = float(score)
+            for bid in currently_reading_ids:
+                scores_map[bid]["session_score"] = 1.0
+            for bid in candidate_ids:
+                scores_map[bid].setdefault("content_score", 0.0)
+                scores_map[bid].setdefault("als_score", 0.0)
+                scores_map[bid].setdefault("graph_score", 0.0)
+                scores_map[bid].setdefault("session_score", 0.0)
+                scores_map[bid].setdefault("popularity_score", 0.0)
+                scores_map[bid].setdefault("linucb_score", 0.5)
+            feature_entities_from_batch = await feature_service.engineer_features_batch(
+                user_id, candidate_ids, dict(scores_map), _minimal_session_context()
+            )
+            logger.info(f"Refresh on-logout: wrote features to S3 for {len(candidate_ids)} books")
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, feature_service.materialize_offline_to_online)
+            except Exception as mat_e:
+                logger.warning(f"Feast materialize_incremental failed (non-fatal): {mat_e}")
+        except Exception as e:
+            logger.warning(f"Refresh on-logout: feature write to S3 failed (non-fatal): {e}")
+
+        books_list = await get_books_by_ids(candidate_ids[:200])
+        books_dict = {str(b.get("id") or b.get("_id")): b for b in books_list}
+
+        # Learning-to-Rank: get features (Feast online or from engineered batch), rank, update "Top Picks" in cache
+        ltr_ids, ltr_scores = [], []
+        try:
+            feast_df = get_feast_online_features(user_id, candidate_ids[:200])
+            if feast_df is not None and not feast_df.empty:
+                ltr_ids, ltr_scores = ltr_rank_candidates(user_id, feast_df, top_k=100)
+            elif feature_entities_from_batch:
+                # Fallback: use freshly engineered features as DataFrame for LTR
+                ltr_feature_df = pd.DataFrame(feature_entities_from_batch)
+                if not ltr_feature_df.empty:
+                    ltr_ids, ltr_scores = ltr_rank_candidates(user_id, ltr_feature_df, top_k=100)
+            if ltr_ids:
+                update_cached_category(
+                    user_id, "Top Picks",
+                    _build_category_payload(
+                        "Top Picks",
+                        "Recommended for you by our ranking model",
+                        ltr_ids, ltr_scores, books_dict,
+                    ),
+                )
+        except Exception as e:
+            logger.warning(f"LTR refresh on logout failed for {user_id}: {e}")
+
+        update_cached_category(
+            user_id, "Collaborative Filtering",
+            _build_category_payload(
+                "Collaborative Filtering",
+                "Readers with similar tastes also enjoyed",
+                als_book_ids, cf_scores, books_dict,
+            ),
+        )
+        update_cached_category(
+            user_id, "Session-Based",
+            _build_category_payload(
+                "Session-Based",
+                "Based on your recent activity",
+                session_book_ids, session_scores, books_dict,
+            ),
+        )
+        update_cached_category(
+            user_id, "For You (LinUCB)",
+            _build_category_payload(
+                "For You (LinUCB)",
+                "Personalized picks with exploration",
+                linucb_book_ids, linucb_scores, books_dict,
+            ),
+        )
+        update_cached_category(
+            user_id, "Continue Reading",
+            _build_category_payload(
+                "Continue Reading",
+                "Pick up where you left off",
+                currently_reading_ids,
+                [1.0] * len(currently_reading_ids),
+                books_dict,
+            ),
+        )
+        updated = ["Collaborative Filtering", "Session-Based", "For You (LinUCB)", "Continue Reading", "Top Picks"]
+        return {"status": "ok", "updated": updated}
+    except Exception as e:
+        logger.exception(f"Refresh on-logout failed for {user_id}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/internal/recommend/refresh-graph")
+async def internal_refresh_graph(
+    body: RefreshBody,
+    _: bool = Depends(verify_internal_key),
+):
+    """
+    Run graph recommendation and update cache. Call when user follows or unfollows another user.
+    """
+    user_id = body.user_id
+    loop = asyncio.get_running_loop()
+    try:
+        graph_results = await loop.run_in_executor(None, graph_recommend_books, user_id, 50)
+        graph_book_ids = [bid for bid, _ in graph_results]
+        graph_scores = [score for _, score in graph_results]
+        if not graph_book_ids:
+            update_cached_category(
+                user_id, "Social Recommendations",
+                _build_category_payload("Social Recommendations", "Based on your social network", [], [], {}),
+            )
+            return {"status": "ok", "category": "Social Recommendations", "count": 0}
+        # Write features to S3 for LTR training (graph_score only for this refresh)
+        try:
+            scores_map = defaultdict(dict)
+            for bid, score in zip(graph_book_ids, graph_scores):
+                scores_map[bid]["graph_score"] = float(score)
+                scores_map[bid].setdefault("content_score", 0.0)
+                scores_map[bid].setdefault("als_score", 0.0)
+                scores_map[bid].setdefault("session_score", 0.0)
+                scores_map[bid].setdefault("popularity_score", 0.0)
+                scores_map[bid].setdefault("linucb_score", 0.5)
+            _ = await feature_service.engineer_features_batch(
+                user_id, graph_book_ids, dict(scores_map), _minimal_session_context()
+            )
+            logger.info(f"Refresh graph: wrote features to S3 for {len(graph_book_ids)} books")
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, feature_service.materialize_offline_to_online)
+            except Exception as mat_e:
+                logger.warning(f"Feast materialize_incremental failed (non-fatal): {mat_e}")
+        except Exception as e:
+            logger.warning(f"Refresh graph: feature write to S3 failed (non-fatal): {e}")
+        books_list = await get_books_by_ids(graph_book_ids)
+        books_dict = {str(b.get("id") or b.get("_id")): b for b in books_list}
+        payload = _build_category_payload(
+            "Social Recommendations",
+            "Based on your social network",
+            graph_book_ids, graph_scores, books_dict,
+        )
+        update_cached_category(user_id, "Social Recommendations", payload)
+        return {"status": "ok", "category": "Social Recommendations", "count": len(payload["books"])}
+    except Exception as e:
+        logger.exception(f"Refresh graph failed for {user_id}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 async def build_session_context(current_user: dict, request: Request = None) -> Dict[str, Any]:
     """
@@ -287,6 +845,15 @@ async def build_session_context(current_user: dict, request: Request = None) -> 
     return session_context
 
 
+def _minimal_session_context() -> Dict[str, Any]:
+    """Minimal session context for internal refresh endpoints (no Request). Used when writing features to S3."""
+    return {
+        "device": "desktop",
+        "hour_of_day": datetime.now().hour,
+        "user_agent": "",
+    }
+
+
 def _detect_device(request: Request = None) -> str:
     """Detect device type from User-Agent"""
     if not request:
@@ -298,3 +865,57 @@ def _detect_device(request: Request = None) -> str:
     elif "tablet" in ua or "ipad" in ua:
         return "tablet"
     return "desktop"
+
+
+def get_feast_online_features(user_id: str, book_ids: List[str]):
+    """
+    Retrieve features from Feast online store for (user_id, book_id) pairs.
+    Uses get_feast_repo_path() so FEAST_REDIS_URL is applied (feast-redis in K8s).
+    Returns a DataFrame or None if Feast is not available or store is not configured.
+    """
+    if not book_ids:
+        return None
+    from feature_engineering.feature_service import get_feast_repo_path
+    repo_path = get_feast_repo_path()
+    if not os.path.isdir(repo_path):
+        logger.debug(f"Feast repo not found at {repo_path}")
+        return None
+    store = FeatureStore(repo_path=repo_path)
+    entity_keys = [f"{user_id}_{bid}" for bid in book_ids]
+    entity_df = pd.DataFrame({"user_book": entity_keys})
+    feature_vector = store.get_online_features(
+        entity_rows=entity_df.to_dict("records"),
+        features=[
+            "user_book_features:query_id",
+            "user_book_features:retrieval_0",
+            "user_book_features:retrieval_1",
+            "user_book_features:retrieval_2",
+            "user_book_features:retrieval_3",
+            "user_book_features:retrieval_4",
+            "user_book_features:retrieval_5",
+            "user_book_features:genre_match_count",
+            "user_book_features:author_match",
+            "user_book_features:language_match",
+            "user_book_features:avg_rating",
+            "user_book_features:user_rating",
+            "user_book_features:avg_rating_diff",
+            "user_book_features:rating_count",
+            "user_book_features:user_pref_strength",
+            "user_book_features:friend_reads_count",
+            "user_book_features:friend_avg_rating",
+            "user_book_features:author_following",
+            "user_book_features:mutual_likes",
+            "user_book_features:social_proximity",
+            "user_book_features:session_position",
+            "user_book_features:session_genre_drift",
+            "user_book_features:time_since_last_action",
+            "user_book_features:is_mobile",
+            "user_book_features:is_desktop",
+            "user_book_features:is_tablet",
+            "user_book_features:session_length",
+            "user_book_features:global_pop_rank",
+            "user_book_features:trending_score",
+            "user_book_features:intra_list_diversity",
+        ],
+    ).to_df()
+    return feature_vector

--- a/src/recommendation_service/requirements.txt
+++ b/src/recommendation_service/requirements.txt
@@ -18,3 +18,4 @@ torch
 supabase
 feast
 s3fs
+xgboost

--- a/src/recommendation_service/sasrec_inference.py
+++ b/src/recommendation_service/sasrec_inference.py
@@ -121,11 +121,11 @@ def recommend_for_session(user_id: str, top_k: int = 20) -> Tuple[List[str], Lis
     items = _get_user_items(user_id)
     print(f"[SASRec] user_id={user_id}, items={items}")
     if len(items) < 2:
-        return []
+        return [], []
 
     seq_ids = [_item2id[i] for i in items if i in _item2id]
     if len(seq_ids) < 2:
-        return []
+        return [], []
 
     seq_ids = seq_ids[-MAX_LEN:]
     pad_len = MAX_LEN - len(seq_ids)
@@ -159,5 +159,5 @@ def recommend_for_session(user_id: str, top_k: int = 20) -> Tuple[List[str], Lis
             if max_v > min_v:
                 scores = [(s - min_v) / (max_v - min_v) for s in scores]
         
-        print(f"4. [SASRec] user={user_id}: {recs} with scores {scores}")
+        print(f"4. [SASRec] user={user_id}: {recs} with scores {scores} with top_k {top_k}")
         return recs, scores 


### PR DESCRIPTION
Adds a Learning-to-Rank training pipeline and several operational and UI improvements:

- Airflow: add container resource limits to multiple training DAGs (ALS, Graph, LinUCB, SASRec) and introduce a new ltr_training DAG to run LTR jobs on Kubernetes.
- LTR training service: add Dockerfile, entrypoint, training script and requirements for the LTR model.
- Feature store: update Feast config to use an S3-style registry path and point the online store at the Redis service host.
- Frontend: add NetflixStyles.css and update Homepage.tsx to support category-based recommendations, map backend categories to user-facing titles, flatten categories for backward compatibility, and apply dark styling and layout refinements.
- Recommendation service: add LTR ranking support and related code updates.
- Kubernetes manifests and deployments updated to align with service names and resource expectations.

These changes enable LTR training, improve scheduling reliability by specifying resource requests/limits, and enhance the frontend to display grouped recommendation categories. (Note: package lock updates are present but not described here.)