### PR TITLE
Add Ray parallelism to LTR training

### DIFF
--- a/src/model_training_service/ltr_train/entrypoint.sh
+++ b/src/model_training_service/ltr_train/entrypoint.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 set -e
-echo "Running LTR (Learning-to-Rank) training..."
+
+echo "Starting Ray head node..."
+ray start --head --port=6379 --disable-usage-stats
+
+# Wait for Ray to fully start
+sleep 5
+
+echo "Running LTR (Learning-to-Rank) training job..."
 python ltr_train.py
+
+echo "Shutting down Ray..."
+ray stop
+
 echo "LTR training finished."

--- a/src/model_training_service/ltr_train/requirements.txt
+++ b/src/model_training_service/ltr_train/requirements.txt
@@ -6,3 +6,4 @@ boto3
 feast
 s3fs
 redis
+ray


### PR DESCRIPTION
Start/stop a Ray cluster in the entrypoint and refactor ltr_train to use Ray tasks. Key changes: the entrypoint now launches a Ray head node and stops it when finished; label/feature loading and model training/upload functions are converted to @ray.remote tasks (load_labels, load_features_direct_s3, load_features_feast, train_and_upload_s3). Behavior kept: direct S3 parquet read is attempted first with fallback to Feast offline store, model is trained with XGBoost and uploaded to S3. Added ray to requirements, tightened empty-data checks and improved logging. This enables parallel/distributed execution and cleaner lifecycle (ray.init()/ray.shutdown()).