### PR TITLE
Add metrics sidecar, Prometheus/Grafana monitoring

### DIFF
--- a/kubernetes/consumer-deployment.yaml
+++ b/kubernetes/consumer-deployment.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickstream-consumer
+  labels:
+    app: clickstream-consumer
+spec:
+  selector:
+    app: clickstream-consumer
+  ports:
+    - name: http
+      port: 8002
+      targetPort: 8002
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+  type: ClusterIP
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,11 +33,17 @@ spec:
         app: clickstream-consumer
     spec:
       restartPolicy: Always
+      volumes:
+        - name: metrics-data
+          emptyDir: {}
       containers:
         - name: clickstream-consumer
           image: rahulkrish28/clickstream-consumer
           ports:
             - containerPort: 8002
+          volumeMounts:
+            - name: metrics-data
+              mountPath: /metrics-data
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
@@ -48,3 +74,22 @@ spec:
             limits:
               cpu: "200m"
               memory: "256Mi"
+        - name: metrics-sidecar
+          image: rahulkrish28/metrics-sidecar:latest
+          ports:
+            - name: metrics
+              containerPort: 9090
+          env:
+            - name: SERVICE_NAME
+              value: clickstream-consumer
+            - name: METRICS_PORT
+              value: "9090"
+            - name: METRICS_FILE
+              value: /metrics-data/app_metrics.json
+          volumeMounts:
+            - name: metrics-data
+              mountPath: /metrics-data
+          resources:
+            limits:
+              cpu: 50m
+              memory: 64Mi

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -3,6 +3,10 @@ kind: Ingress
 metadata:
   name: bibliophile-ingress
   annotations:
+    # Allow long-running /api/v1/recommend/combined (full pipeline can exceed 60s)
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "75"
     # CORS: allow frontend (e.g. Vite dev server on 5173) to call APIs via Ingress (e.g. port 8080)
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:5173"

--- a/kubernetes/monitoring/README.md
+++ b/kubernetes/monitoring/README.md
@@ -1,0 +1,94 @@
+# BibliophileAI Monitoring (Prometheus + Grafana)
+
+Monitoring uses the **Prometheus Operator** (kube-prometheus-stack) for cluster- and node-level metrics, and a **metrics sidecar** in each app pod to expose `/metrics` without adding metrics code to the main application.
+
+## Components
+
+- **Prometheus** – scrapes ServiceMonitors (app sidecars + node-exporter + kube-state-metrics), stores metrics.
+- **Grafana** – dashboards for cluster, nodes, and BibliophileAI app metrics (CTR, NDCG, training, etc.).
+- **Metrics sidecar** – one container per app pod: reads optional `/metrics-data/app_metrics.json` and exposes Prometheus metrics on port 9090.
+
+## Quick start
+
+1. **Build and push the metrics-sidecar image** (once):
+   ```bash
+   docker build -t rahulkrish28/metrics-sidecar:latest src/metrics_sidecar
+   docker push rahulkrish28/metrics-sidecar:latest
+   ```
+
+2. **Install the monitoring stack**:
+   ```bash
+   cd kubernetes/monitoring
+   ./install-monitoring.sh
+   # Or build sidecar and install: ./install-monitoring.sh --build
+   ```
+
+3. **Apply ServiceMonitors and deployments** (so Prometheus scrapes app metrics):
+   ```bash
+   # install-monitoring.sh now applies ServiceMonitors automatically
+   kubectl apply -f kubernetes/user-auth-deployment.yaml
+   kubectl apply -f kubernetes/search-deployment.yaml
+   kubectl apply -f kubernetes/recommendation-deployment.yaml
+   kubectl apply -f kubernetes/consumer-deployment.yaml
+   ```
+   Services must have labels matching the ServiceMonitors (e.g. `app: recommendation`) so Prometheus discovers the metrics endpoints.
+
+4. **Access Grafana** (default admin/admin):
+   ```bash
+   kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
+   ```
+   Open http://localhost:3000. Use **Explore** with datasource **Prometheus** to run queries.
+
+5. **Access Prometheus**:
+   ```bash
+   kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090
+   ```
+   Open http://localhost:9090.
+
+## Dashboards
+
+- **Built-in** (from kube-prometheus-stack): Node Exporter, Kubernetes / cluster, Prometheus, etc.
+- **BibliophileAI – App metrics**: CTR, NDCG@k, training metrics per algorithm, events processed. Loaded from the `grafana-dashboard-bibliophile-app` ConfigMap.
+
+## Exposing app metrics (optional, no code in main app)
+
+Each pod has a shared volume at `/metrics-data`. The main container can write a JSON file there; the sidecar reads it and exposes Prometheus metrics. **No Prometheus or metrics logic in the main app** – only writing a JSON file.
+
+**File:** `/metrics-data/app_metrics.json` (inside the pod)
+
+**Example shape:**
+
+```json
+{
+  "http_requests_total": { "GET|/api/v1/books|2xx": 1000 },
+  "http_errors_total": { "GET|/api/v1/books": 5 },
+  "events_processed_total": { "page_turn": 10000, "bookmark_add": 500 }
+}
+```
+
+- **http_requests_total** / **http_errors_total**: keys like `"METHOD|PATH|STATUS_CLASS"` or `"METHOD|PATH"` for errors.
+- **ctr**: click-through rate per category (0–1).
+- **ndcg_at_k**: NDCG per category and k (e.g. `"5"`, `"10"`).
+- **training**: per-algorithm metrics (e.g. ndcg, loss) and optional **duration_seconds**, **phase**.
+- **events_processed_total**: counts per event type (e.g. clickstream consumer).
+
+The sidecar polls this file every 15s and exports the values as Prometheus gauges. If the file is missing, only `metrics_sidecar_up` and process metrics are exposed.
+
+## ServiceMonitors
+
+| ServiceMonitor            | Service               | Port 9090 (metrics) |
+|---------------------------|-----------------------|----------------------|
+| user-auth-service         | user-auth-service     | sidecar              |
+| search-service            | search-service        | sidecar              |
+| recommendation-service    | recommendation-service| sidecar              |
+| clickstream-consumer      | clickstream-consumer  | sidecar              |
+| model-training-service    | (when deployed)       | sidecar              |
+
+Prometheus is configured to use all ServiceMonitors in all namespaces (`serviceMonitorSelector: {}`). **ServiceMonitors are applied by `install-monitoring.sh`.** Each app Service must have a matching label (e.g. `app: recommendation`) so the ServiceMonitor can select it. If app metrics show "No data" in Grafana, verify: (1) ServiceMonitors are applied: `kubectl get servicemonitor -n default`; (2) Services have the right labels; (3) App pods are running with the metrics sidecar; (4) In Prometheus → Status → Targets, the app endpoints show as "up".
+
+## Cluster and node metrics
+
+- **Node metrics**: node-exporter DaemonSet (CPU, memory, disk, network per node).
+- **Cluster metrics**: kube-state-metrics (pods, deployments, statefulsets, etc.).
+
+Both are included in kube-prometheus-stack and appear in the default Kubernetes and Node dashboards in Grafana.

--- a/kubernetes/monitoring/grafana-dashboards/bibliophile-app-metrics.json
+++ b/kubernetes/monitoring/grafana-dashboards/bibliophile-app-metrics.json
@@ -1,0 +1,207 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0 }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(metrics_sidecar_up)", "refId": "A" }],
+      "title": "Metrics sidecars up",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(app_http_requests_total)", "refId": "A" }],
+      "title": "Total HTTP requests (from app metrics file)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 4 },
+      "id": 8,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "recommendation_cache_hits_total", "refId": "A" }],
+      "title": "Recommendation cache hits",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 4 },
+      "id": 9,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "recommendation_cache_misses_total", "refId": "A" }],
+      "title": "Recommendation cache misses",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 8 },
+      "id": 10,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "recommendation_duration_seconds", "refId": "A" }],
+      "title": "Recommendation generation duration (last)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cluster: total pods in Running phase (includes app pods and Airflow/training pods)",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 12 },
+      "id": 11,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(kube_pod_status_phase{phase=\"Running\"})", "refId": "A" }],
+      "title": "Cluster: Running pods (total)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cluster: pods in Failed phase",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 12 },
+      "id": 12,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(kube_pod_status_phase{phase=\"Failed\"})", "refId": "A" }],
+      "title": "Cluster: Failed pods",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Total HTTP requests across all services (from app metrics)",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 12 },
+      "id": 13,
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "10.0.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(app_http_requests_total)", "refId": "A" }],
+      "title": "Cluster: Total requests",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Available replicas per deployment (app services and Airflow/training deployments)",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 16 },
+      "id": 14,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "kube_deployment_status_replicas_available", "legendFormat": "{{deployment}} ({{namespace}})", "refId": "A" }],
+      "title": "Cluster: Pods (replicas) per deployment",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "CPU usage per node (100 - idle)",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 90 }] }, "unit": "percent" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 22 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)", "legendFormat": "{{instance}}", "refId": "A" }],
+      "title": "Node: CPU usage %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "HTTP request count by service (job) and status class (2xx, 4xx, 5xx)",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 28 },
+      "id": 16,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (job, status_class) (app_http_requests_total)", "legendFormat": "{{job}} {{status_class}}", "refId": "A" }],
+      "title": "HTTP status codes per service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Running pods per namespace (includes default, monitoring, airflow, etc.)",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 34 },
+      "id": 17,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum by (namespace) (kube_pod_status_phase{phase=\"Running\"})", "legendFormat": "{{namespace}}", "refId": "A" }],
+      "title": "Cluster: Running pods by namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisLabel": "", "axisPlacement": "auto" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 39 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "app_events_processed_total", "legendFormat": "{{event_type}}", "refId": "A" }],
+      "title": "Events processed (clickstream consumer)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["bibliophile", "app-metrics"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "BibliophileAI – Cluster, Node & App metrics",
+  "uid": "bibliophile-app-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/monitoring/install-monitoring.sh
+++ b/kubernetes/monitoring/install-monitoring.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install Prometheus Operator stack (Prometheus, Grafana, node-exporter, kube-state-metrics)
+# and optionally build/push the metrics-sidecar image.
+# Usage:
+#   ./install-monitoring.sh              # install stack only
+#   ./install-monitoring.sh --build      # build and push metrics-sidecar image then install
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MONITORING_NS="monitoring"
+KUBE_CONTEXT="${KUBE_CONTEXT:-}"
+
+echo "Adding Helm repo prometheus-community..."
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+
+echo "Creating namespace $MONITORING_NS if not exists..."
+kubectl create namespace "$MONITORING_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Installing kube-prometheus-stack..."
+helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  -n "$MONITORING_NS" \
+  -f "$SCRIPT_DIR/prometheus-stack-values.yaml" \
+  --create-namespace \
+  $([[ -n "$KUBE_CONTEXT" ]] && echo "--kube-context $KUBE_CONTEXT")
+
+echo "Waiting for Prometheus and Grafana to be ready..."
+# Prometheus is a StatefulSet in recent kube-prometheus-stack (not a Deployment)
+kubectl wait --for=condition=ready statefulset/kube-prometheus-stack-prometheus -n "$MONITORING_NS" --timeout=300s 2>/dev/null || \
+  kubectl wait --for=condition=available deployment/kube-prometheus-stack-prometheus -n "$MONITORING_NS" --timeout=300s 2>/dev/null || true
+kubectl wait --for=condition=available deployment/kube-prometheus-stack-grafana -n "$MONITORING_NS" --timeout=300s || true
+
+echo "Creating Grafana dashboard ConfigMap (BibliophileAI app metrics)..."
+kubectl create configmap grafana-dashboard-bibliophile-app \
+  --from-file=bibliophile-app-metrics.json="$SCRIPT_DIR/grafana-dashboards/bibliophile-app-metrics.json" \
+  -n "$MONITORING_NS" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl label configmap grafana-dashboard-bibliophile-app -n "$MONITORING_NS" grafana_dashboard=1 --overwrite
+
+echo "Applying ServiceMonitors (so Prometheus scrapes app metrics from sidecars)..."
+kubectl apply -f "$SCRIPT_DIR/servicemonitors/"
+
+echo ""
+echo "Monitoring stack is installed."
+echo "Access Grafana (default admin/admin):"
+echo "  kubectl port-forward -n $MONITORING_NS svc/kube-prometheus-stack-grafana 3000:80"
+echo "  Open http://localhost:3000"
+echo ""
+echo "Access Prometheus:"
+echo "  kubectl port-forward -n $MONITORING_NS svc/kube-prometheus-stack-prometheus 9090:9090"
+echo "  Open http://localhost:9090"

--- a/kubernetes/monitoring/prometheus-stack-values.yaml
+++ b/kubernetes/monitoring/prometheus-stack-values.yaml
@@ -1,0 +1,45 @@
+# kube-prometheus-stack values for BibliophileAI
+# Install: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#          helm repo update
+#          helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack -n monitoring -f prometheus-stack-values.yaml --create-namespace
+
+# Let Prometheus scrape ServiceMonitors in all namespaces (including default where our apps run)
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector: {}
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector: {}
+    retention: 15d
+    scrapeInterval: 30s
+    evaluationInterval: 30s
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+
+# Grafana: enable and set admin password
+grafana:
+  enabled: true
+  adminPassword: "admin"  # override in production via --set or sealed-secrets
+  persistence:
+    enabled: true
+    size: 5Gi
+  # Ingress optional - use port-forward for local: kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
+  defaultDashboardsEnabled: true
+  defaultDashboardsTimezone: utc
+
+# Node exporter (node-level metrics)
+nodeExporter:
+  enabled: true
+
+# Kube state metrics (cluster-level: pods, deployments, etc.)
+kubeStateMetrics:
+  enabled: true
+
+# Alertmanager optional
+alertmanager:
+  enabled: true

--- a/kubernetes/monitoring/servicemonitors/clickstream-consumer-servicemonitor.yaml
+++ b/kubernetes/monitoring/servicemonitors/clickstream-consumer-servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clickstream-consumer
+  namespace: default
+  labels:
+    app: clickstream-consumer
+spec:
+  selector:
+    matchLabels:
+      app: clickstream-consumer
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics
+    scrapeTimeout: 10s

--- a/kubernetes/monitoring/servicemonitors/recommendation-servicemonitor.yaml
+++ b/kubernetes/monitoring/servicemonitors/recommendation-servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: recommendation-service
+  namespace: default
+  labels:
+    app: recommendation
+spec:
+  selector:
+    matchLabels:
+      app: recommendation
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics
+    scrapeTimeout: 10s

--- a/kubernetes/monitoring/servicemonitors/search-servicemonitor.yaml
+++ b/kubernetes/monitoring/servicemonitors/search-servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: search-service
+  namespace: default
+  labels:
+    app: search
+spec:
+  selector:
+    matchLabels:
+      app: search
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics
+    scrapeTimeout: 10s

--- a/kubernetes/monitoring/servicemonitors/user-auth-servicemonitor.yaml
+++ b/kubernetes/monitoring/servicemonitors/user-auth-servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: user-auth-service
+  namespace: default
+  labels:
+    app: user-auth
+spec:
+  selector:
+    matchLabels:
+      app: user-auth
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics
+    scrapeTimeout: 10s

--- a/kubernetes/recommendation-deployment.yaml
+++ b/kubernetes/recommendation-deployment.yaml
@@ -2,13 +2,20 @@ apiVersion: v1
 kind: Service
 metadata:
   name: recommendation-service
+  labels:
+    app: recommendation
 spec:
   selector:
     app: recommendation
   ports:
-  - port: 8001                    
-    targetPort: 8001 
-    protocol: TCP            
+  - name: http
+    port: 8001
+    targetPort: 8001
+    protocol: TCP
+  - name: metrics
+    port: 9090
+    targetPort: 9090
+    protocol: TCP
   type: ClusterIP
 
 ---
@@ -26,11 +33,17 @@ spec:
       labels:
         app: recommendation
     spec:
+      volumes:
+      - name: metrics-data
+        emptyDir: {}
       containers:
       - name: recommendation
         image: rahulkrish28/recommendation-service:latest
         ports:
-        - containerPort: 8001        
+        - containerPort: 8001
+        volumeMounts:
+        - name: metrics-data
+          mountPath: /metrics-data
         env:
         - name: SECRET_KEY
           valueFrom:
@@ -125,4 +138,23 @@ spec:
             secretKeyRef:
               name: secret
               key: INTERNAL_API_KEY
+      - name: metrics-sidecar
+        image: rahulkrish28/metrics-sidecar:latest
+        ports:
+        - name: metrics
+          containerPort: 9090
+        env:
+        - name: SERVICE_NAME
+          value: recommendation
+        - name: METRICS_PORT
+          value: "9090"
+        - name: METRICS_FILE
+          value: /metrics-data/app_metrics.json
+        volumeMounts:
+        - name: metrics-data
+          mountPath: /metrics-data
+        resources:
+          limits:
+            cpu: 50m
+            memory: 64Mi
 

--- a/kubernetes/search-deployment.yaml
+++ b/kubernetes/search-deployment.yaml
@@ -2,12 +2,19 @@ apiVersion: v1
 kind: Service
 metadata:
   name: search-service
+  labels:
+    app: search
 spec:
   selector:
     app: search
   ports:
-    - port: 8002
+    - name: http
+      port: 8002
       targetPort: 8002
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: 9090
       protocol: TCP
   type: ClusterIP
 
@@ -26,11 +33,17 @@ spec:
       labels:
         app: search
     spec:
+      volumes:
+        - name: metrics-data
+          emptyDir: {}
       containers:
         - name: search
           image: rahulkrish28/search-service:latest
           ports:
             - containerPort: 8002
+          volumeMounts:
+            - name: metrics-data
+              mountPath: /metrics-data
           env:
             - name: SUPABASE_URL
               valueFrom:
@@ -49,3 +62,22 @@ spec:
                   key: PINECONE_API_KEY
             - name: BOOK_INDEX_NAME
               value: "book-metadata-index"
+        - name: metrics-sidecar
+          image: rahulkrish28/metrics-sidecar:latest
+          ports:
+            - name: metrics
+              containerPort: 9090
+          env:
+            - name: SERVICE_NAME
+              value: search
+            - name: METRICS_PORT
+              value: "9090"
+            - name: METRICS_FILE
+              value: /metrics-data/app_metrics.json
+          volumeMounts:
+            - name: metrics-data
+              mountPath: /metrics-data
+          resources:
+            limits:
+              cpu: 50m
+              memory: 64Mi

--- a/kubernetes/user-auth-deployment.yaml
+++ b/kubernetes/user-auth-deployment.yaml
@@ -2,12 +2,19 @@ apiVersion: v1
 kind: Service
 metadata:
   name: user-auth-service
+  labels:
+    app: user-auth
 spec:
   selector:
     app: user-auth
   ports:
-  - port: 8000
+  - name: http
+    port: 8000
     targetPort: 8000
+    protocol: TCP
+  - name: metrics
+    port: 9090
+    targetPort: 9090
     protocol: TCP
   type: ClusterIP
 
@@ -26,11 +33,17 @@ spec:
       labels:
         app: user-auth
     spec:
+      volumes:
+      - name: metrics-data
+        emptyDir: {}
       containers:
       - name: user-auth
         image: rahulkrish28/user-auth-service:latest
         ports:
         - containerPort: 8000
+        volumeMounts:
+        - name: metrics-data
+          mountPath: /metrics-data
         env:
         - name: SECRET_KEY
           valueFrom:
@@ -102,4 +115,23 @@ spec:
             secretKeyRef:
               name: secret
               key: INTERNAL_API_KEY
+      - name: metrics-sidecar
+        image: rahulkrish28/metrics-sidecar:latest
+        ports:
+        - name: metrics
+          containerPort: 9090
+        env:
+        - name: SERVICE_NAME
+          value: user-auth
+        - name: METRICS_PORT
+          value: "9090"
+        - name: METRICS_FILE
+          value: /metrics-data/app_metrics.json
+        volumeMounts:
+        - name: metrics-data
+          mountPath: /metrics-data
+        resources:
+          limits:
+            cpu: 50m
+            memory: 64Mi
 

--- a/src/clickstream_consumer/app_metrics.py
+++ b/src/clickstream_consumer/app_metrics.py
@@ -1,0 +1,54 @@
+"""
+Write /metrics-data/app_metrics.json for the metrics sidecar. No Prometheus dependency.
+"""
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, Optional
+
+
+class MetricsStore:
+    """Thread-safe store for event metrics, written to JSON for the metrics sidecar."""
+
+    def __init__(
+        self,
+        metrics_file: Optional[str] = None,
+        write_interval: Optional[float] = None,
+    ) -> None:
+        self._metrics_file = metrics_file or os.getenv("METRICS_FILE", "/metrics-data/app_metrics.json")
+        self._write_interval = write_interval or float(os.getenv("METRICS_WRITE_INTERVAL", "15.0"))
+        self._lock = threading.Lock()
+        self._events_processed: Dict[str, int] = defaultdict(int)
+
+    def record_event(self, event_type: str) -> None:
+        with self._lock:
+            self._events_processed[event_type] += 1
+
+    def _build_payload(self) -> dict:
+        with self._lock:
+            return {"events_processed_total": dict(self._events_processed)}
+
+    def _write_loop(self) -> None:
+        while True:
+            time.sleep(self._write_interval)
+            parent = os.path.dirname(self._metrics_file)
+            if not os.path.isdir(parent):
+                continue
+            try:
+                payload = self._build_payload()
+                with open(self._metrics_file, "w") as f:
+                    json.dump(payload, f, indent=0)
+            except Exception:
+                pass
+
+    def start_metrics_writer(self) -> None:
+        t = threading.Thread(target=self._write_loop, daemon=True)
+        t.start()
+
+
+_store = MetricsStore()
+
+record_event = _store.record_event
+start_metrics_writer = _store.start_metrics_writer

--- a/src/clickstream_consumer/consumer.py
+++ b/src/clickstream_consumer/consumer.py
@@ -6,12 +6,15 @@ import time
 import logging
 from pymongo.mongo_client import MongoClient
 from pymongo.server_api import ServerApi
+from app_metrics import record_event, start_metrics_writer
+
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 
-# SQS
+# SQS (region required by boto3; use AWS_REGION or AWS_DEFAULT_REGION)
+_aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 try:
-    sqs = boto3.client("sqs")
+    sqs = boto3.client("sqs", region_name=_aws_region)
     QUEUE_URL = os.environ["SQS_QUEUE_URL"]
 except KeyError:
     raise RuntimeError("SQS_QUEUE_URL not set in environment")
@@ -39,7 +42,9 @@ def process_msg(msg):
         data = json.loads(msg['Body'])
         data["received_at"] = datetime.utcnow()
         collection.insert_one(data)
-        logging.info(f"Inserted to mongo: {data.get('event')} for user {data.get('user_id')}")
+        event_type = data.get("event_type") or data.get("event") or "unknown"
+        record_event(event_type)
+        logging.info(f"Inserted to mongo: {event_type} for user {data.get('user_id')}")
     except Exception as e:
         logging.error(f"Failed to process message: {e}")
 
@@ -66,6 +71,7 @@ def consume():
         logging.error(f"Error receiving messages: {e}")
 
 def run_consumer():
+    start_metrics_writer()
     logging.info("Starting SQS consumer with long polling...")
     while True:
         consume()

--- a/src/metrics_sidecar/Dockerfile
+++ b/src/metrics_sidecar/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY exporter.py .
+
+EXPOSE 9090
+ENV METRICS_PORT=9090
+CMD ["python", "-u", "exporter.py"]

--- a/src/metrics_sidecar/exporter.py
+++ b/src/metrics_sidecar/exporter.py
@@ -1,0 +1,136 @@
+"""
+Metrics sidecar: exposes /metrics in Prometheus format.
+Reads app-provided metrics from shared volume (JSON). No metrics logic in main app.
+"""
+import json
+import os
+import logging
+import time
+from prometheus_client import start_http_server, REGISTRY, Gauge, Counter, PROCESS_COLLECTOR
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("metrics-sidecar")
+
+METRICS_FILE = os.environ.get("METRICS_FILE", "/metrics-data/app_metrics.json")
+METRICS_PORT = int(os.environ.get("METRICS_PORT", "9090"))
+SERVICE_NAME = os.environ.get("SERVICE_NAME", "app")
+SCRAPE_INTERVAL = float(os.environ.get("SCRAPE_INTERVAL", "15.0"))
+
+# App metrics from file - all Gauges so app can write absolute values
+app_http_requests_total = Gauge(
+    "app_http_requests_total",
+    "Total HTTP requests (from app metrics file)",
+    ["method", "path", "status_class"],
+    registry=REGISTRY,
+)
+app_http_errors_total = Gauge(
+    "app_http_errors_total",
+    "Total HTTP errors (from app metrics file)",
+    ["method", "path"],
+    registry=REGISTRY,
+)
+app_events_processed_total = Gauge(
+    "app_events_processed_total",
+    "Total events processed (from app metrics file)",
+    ["event_type"],
+    registry=REGISTRY,
+)
+recommendation_cache_hits_total = Gauge(
+    "recommendation_cache_hits_total",
+    "Total recommendation cache hits (combined endpoint)",
+    registry=REGISTRY,
+)
+recommendation_cache_misses_total = Gauge(
+    "recommendation_cache_misses_total",
+    "Total recommendation cache misses (combined endpoint)",
+    registry=REGISTRY,
+)
+recommendation_duration_seconds = Gauge(
+    "recommendation_duration_seconds",
+    "Time taken to generate recommendation results (last cache-miss request)",
+    registry=REGISTRY,
+)
+sidecar_up = Gauge("metrics_sidecar_up", "Sidecar is running", ["service"], registry=REGISTRY)
+
+
+def read_app_metrics():
+    try:
+        with open(METRICS_FILE, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        logger.warning("Invalid JSON in %s: %s", METRICS_FILE, e)
+        return None
+    except Exception as e:
+        logger.warning("Failed to read %s: %s", METRICS_FILE, e)
+        return None
+
+
+def apply_metrics(data: dict):
+    if not data:
+        return
+    # HTTP: expect {"http_requests_total": {"method|path|status_class": value}} or nested
+    if "http_requests_total" in data and isinstance(data["http_requests_total"], dict):
+        for label_str, v in data["http_requests_total"].items():
+            parts = label_str.split("|")
+            if len(parts) >= 3:
+                method, path, status_class = parts[0], parts[1], parts[2]
+            else:
+                method, path, status_class = "GET", "unknown", "2xx"
+            try:
+                app_http_requests_total.labels(method=method, path=path, status_class=status_class).set(float(v))
+            except Exception:
+                pass
+    if "http_errors_total" in data and isinstance(data["http_errors_total"], dict):
+        for label_str, v in data["http_errors_total"].items():
+            parts = label_str.split("|")
+            method, path = (parts[0], parts[1]) if len(parts) >= 2 else ("GET", "unknown")
+            try:
+                app_http_errors_total.labels(method=method, path=path).set(float(v))
+            except Exception:
+                pass
+
+    # Events
+    if "events_processed_total" in data and isinstance(data["events_processed_total"], dict):
+        for ev_type, v in data["events_processed_total"].items():
+            try:
+                app_events_processed_total.labels(event_type=str(ev_type)).set(float(v))
+            except Exception:
+                pass
+    # Recommendation cache
+    if "recommendation_cache_hits_total" in data:
+        try:
+            recommendation_cache_hits_total.set(float(data["recommendation_cache_hits_total"]))
+        except (TypeError, ValueError):
+            pass
+    if "recommendation_cache_misses_total" in data:
+        try:
+            recommendation_cache_misses_total.set(float(data["recommendation_cache_misses_total"]))
+        except (TypeError, ValueError):
+            pass
+    if "recommendation_duration_seconds" in data:
+        try:
+            recommendation_duration_seconds.set(float(data["recommendation_duration_seconds"]))
+        except (TypeError, ValueError):
+            pass
+
+
+def main():
+    # Expose process and platform metrics for the sidecar (optional cluster/node view per pod)
+    try:
+        REGISTRY.register(PROCESS_COLLECTOR)
+    except Exception:
+        pass
+    logger.info("Starting metrics sidecar on port %s (service=%s)", METRICS_PORT, SERVICE_NAME)
+    sidecar_up.labels(service=SERVICE_NAME).set(1)
+    start_http_server(METRICS_PORT)
+    while True:
+        data = read_app_metrics()
+        if data:
+            apply_metrics(data)
+        time.sleep(SCRAPE_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metrics_sidecar/requirements.txt
+++ b/src/metrics_sidecar/requirements.txt
@@ -1,0 +1,1 @@
+prometheus-client==0.21.0

--- a/src/recommendation_service/app_metrics.py
+++ b/src/recommendation_service/app_metrics.py
@@ -1,0 +1,96 @@
+"""
+Write /metrics-data/app_metrics.json for the metrics sidecar. No Prometheus dependency.
+Supports HTTP metrics and recommendation cache/duration metrics.
+"""
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, Optional
+
+
+class MetricsStore:
+    """Thread-safe store for HTTP and recommendation metrics, written to JSON for the metrics sidecar."""
+
+    def __init__(
+        self,
+        metrics_file: Optional[str] = None,
+        write_interval: Optional[float] = None,
+    ) -> None:
+        self._metrics_file = metrics_file or os.getenv("METRICS_FILE", "/metrics-data/app_metrics.json")
+        self._write_interval = write_interval or float(os.getenv("METRICS_WRITE_INTERVAL", "15.0"))
+        self._lock = threading.Lock()
+        self._http_requests: Dict[str, int] = defaultdict(int)
+        self._http_errors: Dict[str, int] = defaultdict(int)
+        self._cache_hits: int = 0
+        self._cache_misses: int = 0
+        self._last_recommendation_duration_seconds: float = 0.0
+
+    @staticmethod
+    def _status_class(status_code: int) -> str:
+        if status_code < 400:
+            return "2xx"
+        if status_code < 500:
+            return "4xx"
+        return "5xx"
+
+    def record_request(self, method: str, path: str, status_code: int) -> None:
+        key = f"{method}|{path}|{self._status_class(status_code)}"
+        with self._lock:
+            self._http_requests[key] += 1
+
+    def record_error(self, method: str, path: str) -> None:
+        key = f"{method}|{path}"
+        with self._lock:
+            self._http_errors[key] += 1
+
+    def record_cache_hit(self) -> None:
+        with self._lock:
+            self._cache_hits += 1
+
+    def record_cache_miss(self) -> None:
+        with self._lock:
+            self._cache_misses += 1
+
+    def record_recommendation_duration_seconds(self, seconds: float) -> None:
+        """Record time taken to generate recommendation results (on cache miss)."""
+        with self._lock:
+            self._last_recommendation_duration_seconds = seconds
+
+    def _build_payload(self) -> dict:
+        with self._lock:
+            return {
+                "http_requests_total": dict(self._http_requests),
+                "http_errors_total": dict(self._http_errors),
+                "recommendation_cache_hits_total": self._cache_hits,
+                "recommendation_cache_misses_total": self._cache_misses,
+                "recommendation_duration_seconds": self._last_recommendation_duration_seconds,
+            }
+
+    def _write_loop(self) -> None:
+        while True:
+            time.sleep(self._write_interval)
+            parent = os.path.dirname(self._metrics_file)
+            if not os.path.isdir(parent):
+                continue
+            try:
+                payload = self._build_payload()
+                with open(self._metrics_file, "w") as f:
+                    json.dump(payload, f, indent=0)
+            except Exception:
+                pass
+
+    def start_metrics_writer(self) -> None:
+        t = threading.Thread(target=self._write_loop, daemon=True)
+        t.start()
+
+
+_store = MetricsStore()
+
+record_request = _store.record_request
+record_error = _store.record_error
+record_cache_hit = _store.record_cache_hit
+record_cache_miss = _store.record_cache_miss
+record_recommendation_duration_seconds = _store.record_recommendation_duration_seconds
+start_metrics_writer = _store.start_metrics_writer

--- a/src/recommendation_service/linucb_inference.py
+++ b/src/recommendation_service/linucb_inference.py
@@ -212,8 +212,8 @@ class LinUCBServe:
         try:
             A_inv = np.linalg.inv(A)
             theta = A_inv @ b
-            mean = float((theta.T @ x))
-            unc = float(np.sqrt(x.T @ A_inv @ x))
+            mean = (theta.T @ x).item()
+            unc = (np.sqrt(x.T @ A_inv @ x)).item()
             return mean + self.alpha * unc
         except np.linalg.LinAlgError:
             return 0.5

--- a/src/search_service/app_metrics.py
+++ b/src/search_service/app_metrics.py
@@ -1,0 +1,73 @@
+"""
+Write /metrics-data/app_metrics.json for the metrics sidecar. No Prometheus dependency.
+"""
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, Optional
+
+
+class MetricsStore:
+    """Thread-safe store for HTTP metrics, written to JSON for the metrics sidecar."""
+
+    def __init__(
+        self,
+        metrics_file: Optional[str] = None,
+        write_interval: Optional[float] = None,
+    ) -> None:
+        self._metrics_file = metrics_file or os.getenv("METRICS_FILE", "/metrics-data/app_metrics.json")
+        self._write_interval = write_interval or float(os.getenv("METRICS_WRITE_INTERVAL", "15.0"))
+        self._lock = threading.Lock()
+        self._http_requests: Dict[str, int] = defaultdict(int)
+        self._http_errors: Dict[str, int] = defaultdict(int)
+
+    @staticmethod
+    def _status_class(status_code: int) -> str:
+        if status_code < 400:
+            return "2xx"
+        if status_code < 500:
+            return "4xx"
+        return "5xx"
+
+    def record_request(self, method: str, path: str, status_code: int) -> None:
+        key = f"{method}|{path}|{self._status_class(status_code)}"
+        with self._lock:
+            self._http_requests[key] += 1
+
+    def record_error(self, method: str, path: str) -> None:
+        key = f"{method}|{path}"
+        with self._lock:
+            self._http_errors[key] += 1
+
+    def _build_payload(self) -> dict:
+        with self._lock:
+            return {
+                "http_requests_total": dict(self._http_requests),
+                "http_errors_total": dict(self._http_errors),
+            }
+
+    def _write_loop(self) -> None:
+        while True:
+            time.sleep(self._write_interval)
+            parent = os.path.dirname(self._metrics_file)
+            if not os.path.isdir(parent):
+                continue
+            try:
+                payload = self._build_payload()
+                with open(self._metrics_file, "w") as f:
+                    json.dump(payload, f, indent=0)
+            except Exception:
+                pass
+
+    def start_metrics_writer(self) -> None:
+        t = threading.Thread(target=self._write_loop, daemon=True)
+        t.start()
+
+
+_store = MetricsStore()
+
+record_request = _store.record_request
+record_error = _store.record_error
+start_metrics_writer = _store.start_metrics_writer

--- a/src/user_service/app_metrics.py
+++ b/src/user_service/app_metrics.py
@@ -1,0 +1,73 @@
+"""
+Write /metrics-data/app_metrics.json for the metrics sidecar. No Prometheus dependency.
+"""
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, Optional
+
+
+class MetricsStore:
+    """Thread-safe store for HTTP metrics, written to JSON for the metrics sidecar."""
+
+    def __init__(
+        self,
+        metrics_file: Optional[str] = None,
+        write_interval: Optional[float] = None,
+    ) -> None:
+        self._metrics_file = metrics_file or os.getenv("METRICS_FILE", "/metrics-data/app_metrics.json")
+        self._write_interval = write_interval or float(os.getenv("METRICS_WRITE_INTERVAL", "15.0"))
+        self._lock = threading.Lock()
+        self._http_requests: Dict[str, int] = defaultdict(int)
+        self._http_errors: Dict[str, int] = defaultdict(int)
+
+    @staticmethod
+    def _status_class(status_code: int) -> str:
+        if status_code < 400:
+            return "2xx"
+        if status_code < 500:
+            return "4xx"
+        return "5xx"
+
+    def record_request(self, method: str, path: str, status_code: int) -> None:
+        key = f"{method}|{path}|{self._status_class(status_code)}"
+        with self._lock:
+            self._http_requests[key] += 1
+
+    def record_error(self, method: str, path: str) -> None:
+        key = f"{method}|{path}"
+        with self._lock:
+            self._http_errors[key] += 1
+
+    def _build_payload(self) -> dict:
+        with self._lock:
+            return {
+                "http_requests_total": dict(self._http_requests),
+                "http_errors_total": dict(self._http_errors),
+            }
+
+    def _write_loop(self) -> None:
+        while True:
+            time.sleep(self._write_interval)
+            parent = os.path.dirname(self._metrics_file)
+            if not os.path.isdir(parent):
+                continue
+            try:
+                payload = self._build_payload()
+                with open(self._metrics_file, "w") as f:
+                    json.dump(payload, f, indent=0)
+            except Exception:
+                pass
+
+    def start_metrics_writer(self) -> None:
+        t = threading.Thread(target=self._write_loop, daemon=True)
+        t.start()
+
+
+_store = MetricsStore()
+
+record_request = _store.record_request
+record_error = _store.record_error
+start_metrics_writer = _store.start_metrics_writer


### PR DESCRIPTION
Introduce a metrics sidecar and Prometheus/Grafana monitoring for app metrics. Adds a lightweight metrics-sidecar service (src/metrics_sidecar) that reads /metrics-data/app_metrics.json and exposes Prometheus metrics on port 9090; Dockerfile and requirements included. Update Kubernetes deployments and Services (user-auth, search, recommendation, clickstream-consumer) to add shared emptyDir volumes, expose a metrics port, label services, and run the sidecar container. Add ServiceMonitor manifests, a Grafana dashboard, Prometheus values, install script, and a README to install and configure the stack. Also: wire simple JSON-based metrics writers into services (clickstream_consumer and recommendation_service), fix consumer boto3 region handling, minor numeric fixes in linucb_inference, and extend Ingress timeouts + make ingress installer retry applying the resource to allow admission webhooks to become ready.